### PR TITLE
Enhance constants lookup and add unit testing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,4 +35,5 @@ android {
 
 dependencies {
     implementation 'com.instabug.library:instabug:8.1.2'
+    testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
@@ -3,6 +3,8 @@ package com.instabug.instabugflutter;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import com.instabug.library.InstabugColorTheme;
+
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -44,6 +46,7 @@ final class ArgsRegistry {
         registerInstabugInvocationEventsArgs(ARGS);
         registerWelcomeMessageArgs(ARGS);
         registerLocaleArgs(ARGS);
+        registerColorThemeArgs(ARGS);
     }
 
     /**
@@ -124,5 +127,11 @@ final class ArgsRegistry {
         args.put("Locale.Spanish", new Locale(SPANISH.getCode(), SPANISH.getCountry()));
         args.put("Locale.Swedish", new Locale(SWEDISH.getCode(), SWEDISH.getCountry()));
         args.put("Locale.Turkish", new Locale(TURKISH.getCode(), TURKISH.getCountry()));
+    }
+
+    @VisibleForTesting
+    static void registerColorThemeArgs(Map<String, Object> args) {
+        args.put("ColorTheme.dark", InstabugColorTheme.InstabugColorThemeDark);
+        args.put("ColorTheme.light", InstabugColorTheme.InstabugColorThemeLight);
     }
 }

--- a/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
@@ -15,14 +15,18 @@ import static com.instabug.library.internal.module.InstabugLocale.DANISH;
 import static com.instabug.library.internal.module.InstabugLocale.ENGLISH;
 import static com.instabug.library.internal.module.InstabugLocale.FRENCH;
 import static com.instabug.library.internal.module.InstabugLocale.GERMAN;
+import static com.instabug.library.internal.module.InstabugLocale.INDONESIAN;
 import static com.instabug.library.internal.module.InstabugLocale.ITALIAN;
 import static com.instabug.library.internal.module.InstabugLocale.JAPANESE;
 import static com.instabug.library.internal.module.InstabugLocale.KOREAN;
 import static com.instabug.library.internal.module.InstabugLocale.NETHERLANDS;
+import static com.instabug.library.internal.module.InstabugLocale.NORWEGIAN;
 import static com.instabug.library.internal.module.InstabugLocale.POLISH;
 import static com.instabug.library.internal.module.InstabugLocale.PORTUGUESE_BRAZIL;
+import static com.instabug.library.internal.module.InstabugLocale.PORTUGUESE_PORTUGAL;
 import static com.instabug.library.internal.module.InstabugLocale.RUSSIAN;
 import static com.instabug.library.internal.module.InstabugLocale.SIMPLIFIED_CHINESE;
+import static com.instabug.library.internal.module.InstabugLocale.SLOVAK;
 import static com.instabug.library.internal.module.InstabugLocale.SPANISH;
 import static com.instabug.library.internal.module.InstabugLocale.SWEDISH;
 import static com.instabug.library.internal.module.InstabugLocale.TRADITIONAL_CHINESE;
@@ -123,10 +127,14 @@ final class ArgsRegistry {
         args.put("Locale.Korean", new Locale(KOREAN.getCode(), KOREAN.getCountry()));
         args.put("Locale.Polish", new Locale(POLISH.getCode(), POLISH.getCountry()));
         args.put("Locale.PortugueseBrazil", new Locale(PORTUGUESE_BRAZIL.getCode(), PORTUGUESE_BRAZIL.getCountry()));
+        args.put("Locale.PortuguesePortugal", new Locale(PORTUGUESE_PORTUGAL.getCode(), PORTUGUESE_PORTUGAL.getCountry()));
         args.put("Locale.Russian", new Locale(RUSSIAN.getCode(), RUSSIAN.getCountry()));
         args.put("Locale.Spanish", new Locale(SPANISH.getCode(), SPANISH.getCountry()));
         args.put("Locale.Swedish", new Locale(SWEDISH.getCode(), SWEDISH.getCountry()));
         args.put("Locale.Turkish", new Locale(TURKISH.getCode(), TURKISH.getCountry()));
+        args.put("Locale.Indonesian", new Locale(INDONESIAN.getCode(), INDONESIAN.getCountry()));
+        args.put("Locale.Slovak", new Locale(SLOVAK.getCode(), SLOVAK.getCountry()));
+        args.put("Locale.Norwegian", new Locale(NORWEGIAN.getCode(), NORWEGIAN.getCountry()));
     }
 
     @VisibleForTesting

--- a/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
@@ -1,0 +1,128 @@
+package com.instabug.instabugflutter;
+
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static com.instabug.library.internal.module.InstabugLocale.ARABIC;
+import static com.instabug.library.internal.module.InstabugLocale.CZECH;
+import static com.instabug.library.internal.module.InstabugLocale.DANISH;
+import static com.instabug.library.internal.module.InstabugLocale.ENGLISH;
+import static com.instabug.library.internal.module.InstabugLocale.FRENCH;
+import static com.instabug.library.internal.module.InstabugLocale.GERMAN;
+import static com.instabug.library.internal.module.InstabugLocale.ITALIAN;
+import static com.instabug.library.internal.module.InstabugLocale.JAPANESE;
+import static com.instabug.library.internal.module.InstabugLocale.KOREAN;
+import static com.instabug.library.internal.module.InstabugLocale.NETHERLANDS;
+import static com.instabug.library.internal.module.InstabugLocale.POLISH;
+import static com.instabug.library.internal.module.InstabugLocale.PORTUGUESE_BRAZIL;
+import static com.instabug.library.internal.module.InstabugLocale.RUSSIAN;
+import static com.instabug.library.internal.module.InstabugLocale.SIMPLIFIED_CHINESE;
+import static com.instabug.library.internal.module.InstabugLocale.SPANISH;
+import static com.instabug.library.internal.module.InstabugLocale.SWEDISH;
+import static com.instabug.library.internal.module.InstabugLocale.TRADITIONAL_CHINESE;
+import static com.instabug.library.internal.module.InstabugLocale.TURKISH;
+import static com.instabug.library.invocation.InstabugInvocationEvent.FLOATING_BUTTON;
+import static com.instabug.library.invocation.InstabugInvocationEvent.NONE;
+import static com.instabug.library.invocation.InstabugInvocationEvent.SCREENSHOT;
+import static com.instabug.library.invocation.InstabugInvocationEvent.SHAKE;
+import static com.instabug.library.invocation.InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT;
+import static com.instabug.library.ui.onboarding.WelcomeMessage.State.BETA;
+import static com.instabug.library.ui.onboarding.WelcomeMessage.State.DISABLED;
+import static com.instabug.library.ui.onboarding.WelcomeMessage.State.LIVE;
+
+@SuppressWarnings({"SameParameterValue", "unchecked"})
+final class ArgsRegistry {
+
+    @VisibleForTesting
+    static final Map<String, Object> ARGS = new HashMap<>();
+
+    static {
+        registerInstabugInvocationEventsArgs(ARGS);
+        registerWelcomeMessageArgs(ARGS);
+        registerLocaleArgs(ARGS);
+    }
+
+    /**
+     * This acts as a safe get() method.
+     * It returns the queried value after deserialization if AND ONLY IF it passed the following assertions:
+     * - {@code key} is not null
+     * - {@code key} does exist in the registry
+     * - The value assigned to the {@code key} is not null
+     * - The value assigned to the {@code key} is assignable from and can be casted to {@code clazz}
+     * (i.e. Foo value = getDeserializedValue("key", Foo.class))
+     *
+     * @param key   the key whose associated value is to be returned
+     * @param clazz the type in which the value should be deserialized to
+     * @return the value deserialized if all the assertions were successful, null otherwise
+     */
+    @Nullable
+    static <T> T getDeserializedValue(String key, Class<T> clazz) {
+        if (key != null && ARGS.containsKey(key)) {
+            Object constant = ARGS.get(key);
+            if (constant != null && constant.getClass().isAssignableFrom(clazz)) {
+                return (T) constant;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * This acts as a safe get() method.
+     * It returns the queried raw value if AND ONLY IF it passed the following assertions:
+     * - {@code key} is not null
+     * - {@code key} does exist in the registry
+     * (i.e. Object value = getRawValue("key")
+     *
+     * @param key the key whose associated value is to be returned
+     * @return the value  if all the assertions were successful, null otherwise
+     */
+    @Nullable
+    static Object getRawValue(String key) {
+        if (key != null) {
+            return ARGS.get(key);
+        }
+        return null;
+    }
+
+    @VisibleForTesting
+    static void registerInstabugInvocationEventsArgs(Map<String, Object> args) {
+        args.put("InvocationEvent.none", NONE);
+        args.put("InvocationEvent.screenshot", SCREENSHOT);
+        args.put("InvocationEvent.twoFingersSwipeLeft", TWO_FINGER_SWIPE_LEFT);
+        args.put("InvocationEvent.floatingButton", FLOATING_BUTTON);
+        args.put("InvocationEvent.shake", SHAKE);
+    }
+
+    @VisibleForTesting
+    static void registerWelcomeMessageArgs(Map<String, Object> args) {
+        args.put("WelcomeMessageMode.live", LIVE);
+        args.put("WelcomeMessageMode.beta", BETA);
+        args.put("WelcomeMessageMode.disabled", DISABLED);
+    }
+
+    @VisibleForTesting
+    static void registerLocaleArgs(Map<String, Object> args) {
+        args.put("Locale.Arabic", new Locale(ARABIC.getCode(), ARABIC.getCountry()));
+        args.put("Locale.ChineseSimplified", new Locale(SIMPLIFIED_CHINESE.getCode(), SIMPLIFIED_CHINESE.getCountry()));
+        args.put("Locale.ChineseTraditional", new Locale(TRADITIONAL_CHINESE.getCode(), TRADITIONAL_CHINESE.getCountry()));
+        args.put("Locale.Czech", new Locale(CZECH.getCode(), CZECH.getCountry()));
+        args.put("Locale.Danish", new Locale(DANISH.getCode(), DANISH.getCountry()));
+        args.put("Locale.Dutch", new Locale(NETHERLANDS.getCode(), NETHERLANDS.getCountry()));
+        args.put("Locale.English", new Locale(ENGLISH.getCode(), ENGLISH.getCountry()));
+        args.put("Locale.French", new Locale(FRENCH.getCode(), FRENCH.getCountry()));
+        args.put("Locale.German", new Locale(GERMAN.getCode(), GERMAN.getCountry()));
+        args.put("Locale.Italian", new Locale(ITALIAN.getCode(), ITALIAN.getCountry()));
+        args.put("Locale.Japanese", new Locale(JAPANESE.getCode(), JAPANESE.getCountry()));
+        args.put("Locale.Korean", new Locale(KOREAN.getCode(), KOREAN.getCountry()));
+        args.put("Locale.Polish", new Locale(POLISH.getCode(), POLISH.getCountry()));
+        args.put("Locale.PortugueseBrazil", new Locale(PORTUGUESE_BRAZIL.getCode(), PORTUGUESE_BRAZIL.getCountry()));
+        args.put("Locale.Russian", new Locale(RUSSIAN.getCode(), RUSSIAN.getCountry()));
+        args.put("Locale.Spanish", new Locale(SPANISH.getCode(), SPANISH.getCountry()));
+        args.put("Locale.Swedish", new Locale(SWEDISH.getCode(), SWEDISH.getCountry()));
+        args.put("Locale.Turkish", new Locale(TURKISH.getCode(), TURKISH.getCountry()));
+    }
+}

--- a/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
@@ -49,8 +49,8 @@ final class ArgsRegistry {
     static {
         registerInstabugInvocationEventsArgs(ARGS);
         registerWelcomeMessageArgs(ARGS);
-        registerLocaleArgs(ARGS);
         registerColorThemeArgs(ARGS);
+        registerLocaleArgs(ARGS);
     }
 
     /**
@@ -97,49 +97,49 @@ final class ArgsRegistry {
 
     @VisibleForTesting
     static void registerInstabugInvocationEventsArgs(Map<String, Object> args) {
-        args.put("InvocationEvent.none", NONE);
-        args.put("InvocationEvent.screenshot", SCREENSHOT);
         args.put("InvocationEvent.twoFingersSwipeLeft", TWO_FINGER_SWIPE_LEFT);
         args.put("InvocationEvent.floatingButton", FLOATING_BUTTON);
+        args.put("InvocationEvent.screenshot", SCREENSHOT);
         args.put("InvocationEvent.shake", SHAKE);
+        args.put("InvocationEvent.none", NONE);
     }
 
     @VisibleForTesting
     static void registerWelcomeMessageArgs(Map<String, Object> args) {
+        args.put("WelcomeMessageMode.disabled", DISABLED);
         args.put("WelcomeMessageMode.live", LIVE);
         args.put("WelcomeMessageMode.beta", BETA);
-        args.put("WelcomeMessageMode.disabled", DISABLED);
-    }
-
-    @VisibleForTesting
-    static void registerLocaleArgs(Map<String, Object> args) {
-        args.put("Locale.Arabic", new Locale(ARABIC.getCode(), ARABIC.getCountry()));
-        args.put("Locale.ChineseSimplified", new Locale(SIMPLIFIED_CHINESE.getCode(), SIMPLIFIED_CHINESE.getCountry()));
-        args.put("Locale.ChineseTraditional", new Locale(TRADITIONAL_CHINESE.getCode(), TRADITIONAL_CHINESE.getCountry()));
-        args.put("Locale.Czech", new Locale(CZECH.getCode(), CZECH.getCountry()));
-        args.put("Locale.Danish", new Locale(DANISH.getCode(), DANISH.getCountry()));
-        args.put("Locale.Dutch", new Locale(NETHERLANDS.getCode(), NETHERLANDS.getCountry()));
-        args.put("Locale.English", new Locale(ENGLISH.getCode(), ENGLISH.getCountry()));
-        args.put("Locale.French", new Locale(FRENCH.getCode(), FRENCH.getCountry()));
-        args.put("Locale.German", new Locale(GERMAN.getCode(), GERMAN.getCountry()));
-        args.put("Locale.Italian", new Locale(ITALIAN.getCode(), ITALIAN.getCountry()));
-        args.put("Locale.Japanese", new Locale(JAPANESE.getCode(), JAPANESE.getCountry()));
-        args.put("Locale.Korean", new Locale(KOREAN.getCode(), KOREAN.getCountry()));
-        args.put("Locale.Polish", new Locale(POLISH.getCode(), POLISH.getCountry()));
-        args.put("Locale.PortugueseBrazil", new Locale(PORTUGUESE_BRAZIL.getCode(), PORTUGUESE_BRAZIL.getCountry()));
-        args.put("Locale.PortuguesePortugal", new Locale(PORTUGUESE_PORTUGAL.getCode(), PORTUGUESE_PORTUGAL.getCountry()));
-        args.put("Locale.Russian", new Locale(RUSSIAN.getCode(), RUSSIAN.getCountry()));
-        args.put("Locale.Spanish", new Locale(SPANISH.getCode(), SPANISH.getCountry()));
-        args.put("Locale.Swedish", new Locale(SWEDISH.getCode(), SWEDISH.getCountry()));
-        args.put("Locale.Turkish", new Locale(TURKISH.getCode(), TURKISH.getCountry()));
-        args.put("Locale.Indonesian", new Locale(INDONESIAN.getCode(), INDONESIAN.getCountry()));
-        args.put("Locale.Slovak", new Locale(SLOVAK.getCode(), SLOVAK.getCountry()));
-        args.put("Locale.Norwegian", new Locale(NORWEGIAN.getCode(), NORWEGIAN.getCountry()));
     }
 
     @VisibleForTesting
     static void registerColorThemeArgs(Map<String, Object> args) {
-        args.put("ColorTheme.dark", InstabugColorTheme.InstabugColorThemeDark);
         args.put("ColorTheme.light", InstabugColorTheme.InstabugColorThemeLight);
+        args.put("ColorTheme.dark", InstabugColorTheme.InstabugColorThemeDark);
+    }
+
+    @VisibleForTesting
+    static void registerLocaleArgs(Map<String, Object> args) {
+        args.put("Locale.ChineseTraditional", new Locale(TRADITIONAL_CHINESE.getCode(), TRADITIONAL_CHINESE.getCountry()));
+        args.put("Locale.PortuguesePortugal", new Locale(PORTUGUESE_PORTUGAL.getCode(), PORTUGUESE_PORTUGAL.getCountry()));
+        args.put("Locale.ChineseSimplified", new Locale(SIMPLIFIED_CHINESE.getCode(), SIMPLIFIED_CHINESE.getCountry()));
+        args.put("Locale.PortugueseBrazil", new Locale(PORTUGUESE_BRAZIL.getCode(), PORTUGUESE_BRAZIL.getCountry()));
+        args.put("Locale.Indonesian", new Locale(INDONESIAN.getCode(), INDONESIAN.getCountry()));
+        args.put("Locale.Dutch", new Locale(NETHERLANDS.getCode(), NETHERLANDS.getCountry()));
+        args.put("Locale.Norwegian", new Locale(NORWEGIAN.getCode(), NORWEGIAN.getCountry()));
+        args.put("Locale.Japanese", new Locale(JAPANESE.getCode(), JAPANESE.getCountry()));
+        args.put("Locale.English", new Locale(ENGLISH.getCode(), ENGLISH.getCountry()));
+        args.put("Locale.Italian", new Locale(ITALIAN.getCode(), ITALIAN.getCountry()));
+        args.put("Locale.Russian", new Locale(RUSSIAN.getCode(), RUSSIAN.getCountry()));
+        args.put("Locale.Spanish", new Locale(SPANISH.getCode(), SPANISH.getCountry()));
+        args.put("Locale.Swedish", new Locale(SWEDISH.getCode(), SWEDISH.getCountry()));
+        args.put("Locale.Turkish", new Locale(TURKISH.getCode(), TURKISH.getCountry()));
+        args.put("Locale.Arabic", new Locale(ARABIC.getCode(), ARABIC.getCountry()));
+        args.put("Locale.Danish", new Locale(DANISH.getCode(), DANISH.getCountry()));
+        args.put("Locale.French", new Locale(FRENCH.getCode(), FRENCH.getCountry()));
+        args.put("Locale.German", new Locale(GERMAN.getCode(), GERMAN.getCountry()));
+        args.put("Locale.Korean", new Locale(KOREAN.getCode(), KOREAN.getCountry()));
+        args.put("Locale.Polish", new Locale(POLISH.getCode(), POLISH.getCountry()));
+        args.put("Locale.Slovak", new Locale(SLOVAK.getCode(), SLOVAK.getCountry()));
+        args.put("Locale.Czech", new Locale(CZECH.getCode(), CZECH.getCountry()));
     }
 }

--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -1,12 +1,8 @@
 package com.instabug.instabugflutter;
 
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
-import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
-
 import android.app.Application;
+import android.os.Handler;
+import android.os.Looper;
 
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
@@ -15,22 +11,18 @@ import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.ui.onboarding.WelcomeMessage;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import android.os.Handler;
-import android.os.Looper;
-import android.util.Log;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 
 // import com.instabug.library.InstabugColorTheme;
@@ -46,8 +38,6 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
   final public static String INVOCATION_EVENT_TWO_FINGER_SWIPE_LEFT = "InvocationEvent.twoFingersSwipeLeft";
   final public static String INVOCATION_EVENT_FLOATING_BUTTON = "InvocationEvent.floatingButton";
   final public static String INVOCATION_EVENT_SHAKE = "InvocationEvent.shake";
-
-  private Map<String, Object> constants = getConstants();
 
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
@@ -104,7 +94,8 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
   public void start(Application application, String token, ArrayList<String> invocationEvents) {
     InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[invocationEvents.size()];
     for (int i = 0; i < invocationEvents.size(); i++) {
-      invocationEventsArray[i] = (InstabugInvocationEvent)constants.get(invocationEvents.get(i));
+      String key = invocationEvents.get(i);
+      invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key, InstabugInvocationEvent.class);
     }
     new Instabug.Builder(application, token).setInvocationEvents(invocationEventsArray).build();
   }
@@ -117,7 +108,9 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
    *                          live, or beta.
   */
   public void showWelcomeMessageWithMode(String welcomeMessageMode) {
-      Instabug.showWelcomeMessage((WelcomeMessage.State) constants.get(welcomeMessageMode));
+    WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(
+            welcomeMessageMode, WelcomeMessage.State.class);
+      Instabug.showWelcomeMessage(resolvedWelcomeMessageMode);
   }
 
   /**
@@ -146,186 +139,132 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
    * @param instabugLocale
    */
     public void setLocale(String instabugLocale) {
-        Instabug.setLocale((Locale) constants.get(instabugLocale));
+      Locale resolvedLocale = ArgsRegistry.getDeserializedValue(instabugLocale, Locale.class);
+      Instabug.setLocale(resolvedLocale);
     }
 
-
-   /**
-    * Appends a log message to Instabug internal log
-    * These logs are then sent along the next uploaded report.
-    * All log messages are timestamped
-    * Note: logs passed to this method are NOT printed to Logcat
-    * @param message the message
-    */
+    /**
+     * Appends a log message to Instabug internal log
+     * These logs are then sent along the next uploaded report.
+     * All log messages are timestamped
+     * Note: logs passed to this method are NOT printed to Logcat
+     * @param message the message
+     */
     public void logVerbose(String message) {
-          InstabugLog.v(message);
-     }
-  
-   /**
-    * Appends a log message to Instabug internal log
-    * These logs are then sent along the next uploaded report.
-    * All log messages are timestamped
-    * Note: logs passed to this method are NOT printed to Logcat
-    * @param message the message
-    */
+        InstabugLog.v(message);
+    }
+
+    /**
+     * Appends a log message to Instabug internal log
+     * These logs are then sent along the next uploaded report.
+     * All log messages are timestamped
+     * Note: logs passed to this method are NOT printed to Logcat
+     * @param message the message
+     */
     public void logDebug(String message) {
         InstabugLog.d(message);
-   }
-  
-  /**
-    * Appends a log message to Instabug internal log
-    * These logs are then sent along the next uploaded report.
-    * All log messages are timestamped
-    * Note: logs passed to this method are NOT printed to Logcat
-    * @param message the message
-    */
-     public void logInfo(String message) {
-        InstabugLog.i(message);
-   }
+    }
 
-   /**
-    * Appends a log message to Instabug internal log
-    * These logs are then sent along the next uploaded report.
-    * All log messages are timestamped
-    * Note: logs passed to this method are NOT printed to Logcat
-    * @param message the message
-    */
+    /**
+     * Appends a log message to Instabug internal log
+     * These logs are then sent along the next uploaded report.
+     * All log messages are timestamped
+     * Note: logs passed to this method are NOT printed to Logcat
+     * @param message the message
+     */
+    public void logInfo(String message) {
+        InstabugLog.i(message);
+    }
+
+    /**
+     * Appends a log message to Instabug internal log
+     * These logs are then sent along the next uploaded report.
+     * All log messages are timestamped
+     * Note: logs passed to this method are NOT printed to Logcat
+     * @param message the message
+     */
     public void logError(String message) {
         InstabugLog.e(message);
     }
-    
+
     /**
-    * Appends a log message to Instabug internal log
-    * These logs are then sent along the next uploaded report.
-    * All log messages are timestamped
-    * Note: logs passed to this method are NOT printed to Logcat
-    * @param message the message
-    */
+     * Appends a log message to Instabug internal log
+     * These logs are then sent along the next uploaded report.
+     * All log messages are timestamped
+     * Note: logs passed to this method are NOT printed to Logcat
+     * @param message the message
+     */
     public void logWarn(String message) {
         InstabugLog.w(message);
-   }
+    }
 
-   /**
-    * Clears Instabug internal log
-    */
+    /**
+     * Clears Instabug internal log
+     */
     public void clearAllLogs() {
         InstabugLog.clearLogs();
     }
-    
+
     /**
      * Sets the color theme of the SDK's whole UI.
      * @param colorTheme an InstabugColorTheme to set the SDK's UI to.
      */
-   public void setColorTheme(String colorTheme) {
-         Instabug.setColorTheme((InstabugColorTheme) constants.get(colorTheme));
-   }
+    public void setColorTheme(String colorTheme) {
+        // TODO args
+        Instabug.setColorTheme((InstabugColorTheme) constants.get(colorTheme));
+    }
 
     /**
      * Appends a set of tags to previously added tags of reported feedback, bug or crash.
      * @param tags An array of tags to append to current tags.
      */
-   public void appendTags(ArrayList<String> tags) {
-       Instabug.addTags(tags.toArray(new String[0]));
-   }
+    public void appendTags(ArrayList<String> tags) {
+        Instabug.addTags(tags.toArray(new String[0]));
+    }
 
-  /**
-   * Manually removes all tags of reported feedback, bug or crash.
-   */
-  public void resetTags() {
-     Instabug.resetTags();
-   }
+    /**
+     * Manually removes all tags of reported feedback, bug or crash.
+     */
+    public void resetTags() {
+        Instabug.resetTags();
+    }
 
     /**
      * Gets all tags of reported feedback, bug or crash.
      * @return An array of tags.
      */
-   public ArrayList<String> getTags() {
-      return Instabug.getTags();
-   }
+    public ArrayList<String> getTags() {
+        return Instabug.getTags();
+    }
 
     /**
      * Set custom user attributes that are going to be sent with each feedback, bug or crash.
      * @param value User attribute value.
      * @param key User attribute key.
      */
-   public void setUserAttribute(String value, String key) {
-       Instabug.setUserAttribute(key, value);
-   }
+    public void setUserAttribute(String value, String key) {
+        Instabug.setUserAttribute(key, value);
+    }
 
     /**
      * Removes a given key and its associated value from user attributes.
      * Does nothing if a key does not exist.
      * @param key The key to remove.
      */
-   public void removeUserAttributeForKey(String key) {
-       Instabug.removeUserAttribute(key);
-   }
+    public void removeUserAttributeForKey(String key) {
+        Instabug.removeUserAttribute(key);
+    }
 
-   /**
+    /**
      * invoke sdk manually
      */
     public void show() {
-      Handler handler = new Handler(Looper.getMainLooper());
-            handler.post(new Runnable() {
-                @Override
-                public void run() {
-                  Instabug.show();
-                }
-            });
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                Instabug.show();
+            }
+        });
     }
-
-  public Map<String, Object> getConstants() {
-    final Map<String, Object> constants = new HashMap<>();
-    constants.put("InvocationEvent.none", InstabugInvocationEvent.NONE);
-    constants.put("InvocationEvent.screenshot", InstabugInvocationEvent.SCREENSHOT);
-    constants.put("InvocationEvent.twoFingersSwipeLeft", InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT);
-    constants.put("InvocationEvent.floatingButton", InstabugInvocationEvent.FLOATING_BUTTON);
-    constants.put("InvocationEvent.shake", InstabugInvocationEvent.SHAKE);
-
-    constants.put("WelcomeMessageMode.live", WelcomeMessage.State.LIVE);
-    constants.put("WelcomeMessageMode.beta", WelcomeMessage.State.BETA);
-    constants.put("WelcomeMessageMode.disabled", WelcomeMessage.State.DISABLED);
-
-    constants.put("ColorTheme.dark", InstabugColorTheme.InstabugColorThemeDark);
-    constants.put("ColorTheme.light", InstabugColorTheme.InstabugColorThemeLight);
-
-    constants.put("Locale.Arabic",
-            new Locale(InstabugLocale.ARABIC.getCode(), InstabugLocale.ARABIC.getCountry()));
-    constants.put("Locale.ChineseSimplified",
-            new Locale(InstabugLocale.SIMPLIFIED_CHINESE.getCode(), InstabugLocale.SIMPLIFIED_CHINESE.getCountry()));
-    constants.put("Locale.ChineseTraditional",
-            new Locale(InstabugLocale.TRADITIONAL_CHINESE.getCode(), InstabugLocale.TRADITIONAL_CHINESE.getCountry()));
-    constants.put("Locale.Czech",
-            new Locale(InstabugLocale.CZECH.getCode(), InstabugLocale.CZECH.getCountry()));
-    constants.put("Locale.Danish",
-            new Locale(InstabugLocale.DANISH.getCode(), InstabugLocale.DANISH.getCountry()));
-    constants.put("Locale.Dutch",
-            new Locale(InstabugLocale.NETHERLANDS.getCode(), InstabugLocale.NETHERLANDS.getCountry()));
-    constants.put("Locale.English",
-            new Locale(InstabugLocale.ENGLISH.getCode(), InstabugLocale.ENGLISH.getCountry()));
-    constants.put("Locale.French",
-            new Locale(InstabugLocale.FRENCH.getCode(), InstabugLocale.FRENCH.getCountry()));
-    constants.put("Locale.German",
-            new Locale(InstabugLocale.GERMAN.getCode(), InstabugLocale.GERMAN.getCountry()));
-    constants.put("Locale.Italian",
-            new Locale(InstabugLocale.ITALIAN.getCode(), InstabugLocale.ITALIAN.getCountry()));
-    constants.put("Locale.Japanese",
-            new Locale(InstabugLocale.JAPANESE.getCode(), InstabugLocale.JAPANESE.getCountry()));
-    constants.put("Locale.Korean",
-            new Locale(InstabugLocale.KOREAN.getCode(), InstabugLocale.KOREAN.getCountry()));
-    constants.put("Locale.Polish",
-            new Locale(InstabugLocale.POLISH.getCode(), InstabugLocale.POLISH.getCountry()));
-    constants.put("Locale.PortugueseBrazil",
-            new Locale(InstabugLocale.PORTUGUESE_BRAZIL.getCode(), InstabugLocale.PORTUGUESE_BRAZIL.getCountry()));
-    constants.put("Locale.Russian",
-            new Locale(InstabugLocale.RUSSIAN.getCode(), InstabugLocale.RUSSIAN.getCountry()));
-    constants.put("Locale.Spanish",
-            new Locale(InstabugLocale.SPANISH.getCode(), InstabugLocale.SPANISH.getCountry()));
-    constants.put("Locale.Swedish",
-            new Locale(InstabugLocale.SWEDISH.getCode(), InstabugLocale.SWEDISH.getCountry()));
-    constants.put("Locale.Turkish",
-            new Locale(InstabugLocale.TURKISH.getCode(), InstabugLocale.TURKISH.getCountry()));
-
-    return constants;
-  }
 }

--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -23,117 +23,122 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
-/** InstabugFlutterPlugin */
+/**
+ * InstabugFlutterPlugin
+ */
 public class InstabugFlutterPlugin implements MethodCallHandler {
 
-  final public static String INVOCATION_EVENT_NONE = "InvocationEvent.none";
-  final public static String INVOCATION_EVENT_SCREENSHOT = "InvocationEvent.screenshot";
-  final public static String INVOCATION_EVENT_TWO_FINGER_SWIPE_LEFT = "InvocationEvent.twoFingersSwipeLeft";
-  final public static String INVOCATION_EVENT_FLOATING_BUTTON = "InvocationEvent.floatingButton";
-  final public static String INVOCATION_EVENT_SHAKE = "InvocationEvent.shake";
-
-  /** Plugin registration. */
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "instabug_flutter");
-    channel.setMethodCallHandler(new InstabugFlutterPlugin());
-  }
-
-  @Override
-  public void onMethodCall(MethodCall call, Result result) {
-    Method[] methods = this.getClass().getMethods();
-    boolean isImplemented = false;
-    String callMethod = call.method;
-    if (callMethod.contains(":")) {
-      callMethod = call.method.substring( 0, call.method.indexOf(":"));
-    }
-    for (Method method : methods) {
-      if (callMethod.equals(method.getName())) {
-        isImplemented = true;
-        ArrayList<Object> tempParamValues = new ArrayList<>();
-        HashMap<String, String> map = new HashMap<>();
-        if (call.arguments != null) {
-          map = (HashMap<String, String>) call.arguments;
-        }
-        Iterator iterator = map.entrySet().iterator();
-        while (iterator.hasNext()) {
-          Map.Entry pair = (Map.Entry)iterator.next();
-          tempParamValues.add(pair.getValue());
-          iterator.remove();
-        }
-        Object[] paramValues = tempParamValues.toArray();
-        try {
-           Object returnVal = method.invoke(this, paramValues);
-           result.success(returnVal);
-           break;
-        } catch (Exception e) {
-          e.printStackTrace();
-          result.notImplemented();
-        }
-      }
-    }
-    if (!isImplemented) {
-      result.notImplemented();
-    }
-  }
-  
-  /**
-   * starts the SDK
-   * @param application the application Object
-   * @param token token The token that identifies the app, you can find
-   * it on your dashboard.
-   * @param invocationEvents invocationEvents The events that invoke
-   * the SDK's UI.
-   */
-  public void start(Application application, String token, ArrayList<String> invocationEvents) {
-    InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[invocationEvents.size()];
-    for (int i = 0; i < invocationEvents.size(); i++) {
-      String key = invocationEvents.get(i);
-      invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key, InstabugInvocationEvent.class);
-    }
-    new Instabug.Builder(application, token).setInvocationEvents(invocationEventsArray).build();
-  }
-
-
-  /**
-   * Shows the welcome message in a specific mode.
-   *
-   * @param welcomeMessageMode An enum to set the welcome message mode to
-   *                          live, or beta.
-  */
-  public void showWelcomeMessageWithMode(String welcomeMessageMode) {
-    WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(
-            welcomeMessageMode, WelcomeMessage.State.class);
-      Instabug.showWelcomeMessage(resolvedWelcomeMessageMode);
-  }
-
-  /**
-   * Set the user identity.
-   *
-   * @param userName  Username.
-   * @param userEmail User's default email
-   */
-  public void identifyUserWithEmail(String userEmail, String userName) {
-      Instabug.identifyUser(userEmail, userName);
-  }
+    final public static String INVOCATION_EVENT_NONE = "InvocationEvent.none";
+    final public static String INVOCATION_EVENT_SCREENSHOT = "InvocationEvent.screenshot";
+    final public static String INVOCATION_EVENT_TWO_FINGER_SWIPE_LEFT = "InvocationEvent.twoFingersSwipeLeft";
+    final public static String INVOCATION_EVENT_FLOATING_BUTTON = "InvocationEvent.floatingButton";
+    final public static String INVOCATION_EVENT_SHAKE = "InvocationEvent.shake";
 
     /**
-    * Sets the default value of the user's email to null and show email field and remove user
-    * name from all reports
-    * It also reset the chats on device and removes user attributes, user data and completed
-    * surveys.
-    */
+     * Plugin registration.
+     */
+    public static void registerWith(Registrar registrar) {
+        final MethodChannel channel = new MethodChannel(registrar.messenger(), "instabug_flutter");
+        channel.setMethodCallHandler(new InstabugFlutterPlugin());
+    }
+
+    @Override
+    public void onMethodCall(MethodCall call, Result result) {
+        Method[] methods = this.getClass().getMethods();
+        boolean isImplemented = false;
+        String callMethod = call.method;
+        if (callMethod.contains(":")) {
+            callMethod = call.method.substring(0, call.method.indexOf(":"));
+        }
+        for (Method method : methods) {
+            if (callMethod.equals(method.getName())) {
+                isImplemented = true;
+                ArrayList<Object> tempParamValues = new ArrayList<>();
+                HashMap<String, String> map = new HashMap<>();
+                if (call.arguments != null) {
+                    map = (HashMap<String, String>) call.arguments;
+                }
+                Iterator iterator = map.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry pair = (Map.Entry) iterator.next();
+                    tempParamValues.add(pair.getValue());
+                    iterator.remove();
+                }
+                Object[] paramValues = tempParamValues.toArray();
+                try {
+                    Object returnVal = method.invoke(this, paramValues);
+                    result.success(returnVal);
+                    break;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    result.notImplemented();
+                }
+            }
+        }
+        if (!isImplemented) {
+            result.notImplemented();
+        }
+    }
+
+    /**
+     * starts the SDK
+     *
+     * @param application      the application Object
+     * @param token            token The token that identifies the app, you can find
+     *                         it on your dashboard.
+     * @param invocationEvents invocationEvents The events that invoke
+     *                         the SDK's UI.
+     */
+    public void start(Application application, String token, ArrayList<String> invocationEvents) {
+        InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[invocationEvents.size()];
+        for (int i = 0; i < invocationEvents.size(); i++) {
+            String key = invocationEvents.get(i);
+            invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key, InstabugInvocationEvent.class);
+        }
+        new Instabug.Builder(application, token).setInvocationEvents(invocationEventsArray).build();
+    }
+
+
+    /**
+     * Shows the welcome message in a specific mode.
+     *
+     * @param welcomeMessageMode An enum to set the welcome message mode to
+     *                           live, or beta.
+     */
+    public void showWelcomeMessageWithMode(String welcomeMessageMode) {
+        WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(
+                welcomeMessageMode, WelcomeMessage.State.class);
+        Instabug.showWelcomeMessage(resolvedWelcomeMessageMode);
+    }
+
+    /**
+     * Set the user identity.
+     *
+     * @param userName  Username.
+     * @param userEmail User's default email
+     */
+    public void identifyUserWithEmail(String userEmail, String userName) {
+        Instabug.identifyUser(userEmail, userName);
+    }
+
+    /**
+     * Sets the default value of the user's email to null and show email field and remove user
+     * name from all reports
+     * It also reset the chats on device and removes user attributes, user data and completed
+     * surveys.
+     */
     public void logOut() {
         Instabug.logoutUser();
     }
 
-  /**
-   * Change Locale of Instabug UI elements(defaults to English)
-   *
-   * @param instabugLocale
-   */
+    /**
+     * Change Locale of Instabug UI elements(defaults to English)
+     *
+     * @param instabugLocale
+     */
     public void setLocale(String instabugLocale) {
-      Locale resolvedLocale = ArgsRegistry.getDeserializedValue(instabugLocale, Locale.class);
-      Instabug.setLocale(resolvedLocale);
+        Locale resolvedLocale = ArgsRegistry.getDeserializedValue(instabugLocale, Locale.class);
+        Instabug.setLocale(resolvedLocale);
     }
 
     /**
@@ -141,6 +146,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
      * These logs are then sent along the next uploaded report.
      * All log messages are timestamped
      * Note: logs passed to this method are NOT printed to Logcat
+     *
      * @param message the message
      */
     public void logVerbose(String message) {
@@ -152,6 +158,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
      * These logs are then sent along the next uploaded report.
      * All log messages are timestamped
      * Note: logs passed to this method are NOT printed to Logcat
+     *
      * @param message the message
      */
     public void logDebug(String message) {
@@ -163,6 +170,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
      * These logs are then sent along the next uploaded report.
      * All log messages are timestamped
      * Note: logs passed to this method are NOT printed to Logcat
+     *
      * @param message the message
      */
     public void logInfo(String message) {
@@ -174,6 +182,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
      * These logs are then sent along the next uploaded report.
      * All log messages are timestamped
      * Note: logs passed to this method are NOT printed to Logcat
+     *
      * @param message the message
      */
     public void logError(String message) {
@@ -185,6 +194,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
      * These logs are then sent along the next uploaded report.
      * All log messages are timestamped
      * Note: logs passed to this method are NOT printed to Logcat
+     *
      * @param message the message
      */
     public void logWarn(String message) {
@@ -200,17 +210,19 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
 
     /**
      * Sets the color theme of the SDK's whole UI.
+     *
      * @param colorTheme an InstabugColorTheme to set the SDK's UI to.
      */
     public void setColorTheme(String colorTheme) {
-      InstabugColorTheme resolvedTheme = ArgsRegistry.getDeserializedValue(colorTheme, InstabugColorTheme.class);
-      if (resolvedTheme != null) {
-        Instabug.setColorTheme(resolvedTheme);
-      }
+        InstabugColorTheme resolvedTheme = ArgsRegistry.getDeserializedValue(colorTheme, InstabugColorTheme.class);
+        if (resolvedTheme != null) {
+            Instabug.setColorTheme(resolvedTheme);
+        }
     }
 
     /**
      * Appends a set of tags to previously added tags of reported feedback, bug or crash.
+     *
      * @param tags An array of tags to append to current tags.
      */
     public void appendTags(ArrayList<String> tags) {
@@ -226,6 +238,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
 
     /**
      * Gets all tags of reported feedback, bug or crash.
+     *
      * @return An array of tags.
      */
     public ArrayList<String> getTags() {
@@ -234,8 +247,9 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
 
     /**
      * Set custom user attributes that are going to be sent with each feedback, bug or crash.
+     *
      * @param value User attribute value.
-     * @param key User attribute key.
+     * @param key   User attribute key.
      */
     public void setUserAttribute(String value, String key) {
         Instabug.setUserAttribute(key, value);
@@ -244,6 +258,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
     /**
      * Removes a given key and its associated value from user attributes.
      * Does nothing if a key does not exist.
+     *
      * @param key The key to remove.
      */
     public void removeUserAttributeForKey(String key) {

--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -6,9 +6,8 @@ import android.os.Looper;
 
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
-import com.instabug.library.logging.InstabugLog;
-import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
+import com.instabug.library.logging.InstabugLog;
 import com.instabug.library.ui.onboarding.WelcomeMessage;
 
 import java.lang.reflect.Method;
@@ -23,12 +22,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-
-
-// import com.instabug.library.InstabugColorTheme;
-// import com.instabug.library.InstabugCustomTextPlaceHolder;
-// import com.instabug.library.internal.module.InstabugLocale;
-// import com.instabug.library.ui.onboarding.WelcomeMessage;
 
 /** InstabugFlutterPlugin */
 public class InstabugFlutterPlugin implements MethodCallHandler {
@@ -210,8 +203,10 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
      * @param colorTheme an InstabugColorTheme to set the SDK's UI to.
      */
     public void setColorTheme(String colorTheme) {
-        // TODO args
-        Instabug.setColorTheme((InstabugColorTheme) constants.get(colorTheme));
+      InstabugColorTheme resolvedTheme = ArgsRegistry.getDeserializedValue(colorTheme, InstabugColorTheme.class);
+      if (resolvedTheme != null) {
+        Instabug.setColorTheme(resolvedTheme);
+      }
     }
 
     /**

--- a/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
@@ -1,5 +1,6 @@
 package com.instabug.instabugflutter;
 
+import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.ui.onboarding.WelcomeMessage;
 
@@ -21,8 +22,7 @@ public class ArgsRegistryTest {
         // when
         ArgsRegistry.registerInstabugInvocationEventsArgs(map);
         // then
-        Assert.assertEquals(6, map.size());
-        //TODO fix missing invocation mode
+        Assert.assertEquals(5, map.size());
         assertAllInvocationEventsArePresent(map);
     }
 
@@ -55,6 +55,7 @@ public class ArgsRegistryTest {
         assertAllInvocationEventsArePresent(args);
         assertAllWelcomeMessageStatesArePresent(args);
         assertAllSupportedLocalesArePresent(args);
+        assertAllColorThemesArePresent(args);
     }
 
     @Test
@@ -86,12 +87,21 @@ public class ArgsRegistryTest {
         Assert.assertEquals("en", actualLocale.getLanguage());
     }
 
+    @Test
+    public void given$registerColorThemeArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
+        // given
+        Map<String, Object> map = new HashMap<>();
+        // when
+        ArgsRegistry.registerColorThemeArgs(map);
+        // then
+        assertAllColorThemesArePresent(map);
+    }
+
     private void assertAllInvocationEventsArePresent(Map<String, Object> map) {
         Assert.assertTrue(map.containsValue(InstabugInvocationEvent.NONE));
         Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SHAKE));
         Assert.assertTrue(map.containsValue(InstabugInvocationEvent.FLOATING_BUTTON));
         Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SCREENSHOT));
-        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SCREENSHOT_GESTURE));
         Assert.assertTrue(map.containsValue(InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT));
     }
 
@@ -123,6 +133,11 @@ public class ArgsRegistryTest {
         if (!missingLangs.isEmpty()) {
             Assert.fail(missingLangs);
         }
+    }
+
+    private void assertAllColorThemesArePresent(Map<String, Object> map) {
+        Assert.assertTrue(map.containsValue(InstabugColorTheme.InstabugColorThemeDark));
+        Assert.assertTrue(map.containsValue(InstabugColorTheme.InstabugColorThemeLight));
     }
 
     private List<Locale> getCurrentlySupportLanguagesByTheSDK() {

--- a/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
@@ -1,0 +1,155 @@
+package com.instabug.instabugflutter;
+
+import com.instabug.library.invocation.InstabugInvocationEvent;
+import com.instabug.library.ui.onboarding.WelcomeMessage;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class ArgsRegistryTest {
+
+    @Test
+    public void given$registerInstabugInvocationEventsArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
+        // given
+        Map<String, Object> map = new HashMap<>();
+        // when
+        ArgsRegistry.registerInstabugInvocationEventsArgs(map);
+        // then
+        Assert.assertEquals(6, map.size());
+        //TODO fix missing invocation mode
+        assertAllInvocationEventsArePresent(map);
+    }
+
+    @Test
+    public void given$registerWelcomeMessageArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
+        // given
+        Map<String, Object> map = new HashMap<>();
+        // when
+        ArgsRegistry.registerWelcomeMessageArgs(map);
+        // then
+        Assert.assertEquals(3, map.size());
+        assertAllWelcomeMessageStatesArePresent(map);
+    }
+
+    @Test
+    public void given$registerLocaleArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
+        // given
+        Map<String, Object> map = new HashMap<>();
+        // when
+        ArgsRegistry.registerLocaleArgs(map);
+        // then
+        //TODO fix missing locales
+        assertAllSupportedLocalesArePresent(map);
+    }
+
+    @Test
+    public void given$ArgsRegistryIsInitialized_whenQuery_thenShouldMatchCriteria() {
+        Map<String, Object> args = ArgsRegistry.ARGS;
+        //TODO fix missing invocation mode and missing locales
+        assertAllInvocationEventsArePresent(args);
+        assertAllWelcomeMessageStatesArePresent(args);
+        assertAllSupportedLocalesArePresent(args);
+    }
+
+    @Test
+    public void givenFabInvocationIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
+        // when
+        InstabugInvocationEvent deserializedValue = ArgsRegistry.getDeserializedValue(
+                "InvocationEvent.floatingButton", InstabugInvocationEvent.class);
+        // then
+        Assert.assertNotNull(deserializedValue);
+        Assert.assertEquals(InstabugInvocationEvent.FLOATING_BUTTON, deserializedValue);
+    }
+
+    @Test
+    public void givenWelcomeMessageBetaIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
+        // when
+        WelcomeMessage.State deserializedValue = ArgsRegistry.getDeserializedValue(
+                "WelcomeMessageMode.beta", WelcomeMessage.State.class);
+        // then
+        Assert.assertNotNull(deserializedValue);
+        Assert.assertEquals(WelcomeMessage.State.BETA, deserializedValue);
+    }
+
+    @Test
+    public void givenEnglishLocaleIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
+        // when
+        Locale actualLocale = ArgsRegistry.getDeserializedValue("Locale.English", Locale.class);
+        // then
+        Assert.assertNotNull(actualLocale);
+        Assert.assertEquals("en", actualLocale.getLanguage());
+    }
+
+    private void assertAllInvocationEventsArePresent(Map<String, Object> map) {
+        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.NONE));
+        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SHAKE));
+        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.FLOATING_BUTTON));
+        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SCREENSHOT));
+        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SCREENSHOT_GESTURE));
+        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT));
+    }
+
+    private void assertAllWelcomeMessageStatesArePresent(Map<String, Object> map) {
+        Assert.assertTrue(map.containsValue(WelcomeMessage.State.LIVE));
+        Assert.assertTrue(map.containsValue(WelcomeMessage.State.BETA));
+        Assert.assertTrue(map.containsValue(WelcomeMessage.State.DISABLED));
+    }
+
+    private void assertAllSupportedLocalesArePresent(Map<String, Object> map) {
+        // source of truth
+        List<Locale> expectedLocales = getCurrentlySupportLanguagesByTheSDK();
+        // actual
+        List<Locale> actualLocales = new ArrayList<>();
+        for (Map.Entry m : map.entrySet()) {
+            actualLocales.add((Locale) m.getValue());
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Locale expectedLocale : expectedLocales) {
+            if (!actualLocales.contains(expectedLocale)) {
+                stringBuilder.append(expectedLocale.getLanguage())
+                        .append(" - ")
+                        .append(expectedLocale.getCountry())
+                        .append(" is missing")
+                        .append("\n");
+            }
+        }
+        String missingLangs = stringBuilder.toString();
+        if (!missingLangs.isEmpty()) {
+            Assert.fail(missingLangs);
+        }
+    }
+
+    private List<Locale> getCurrentlySupportLanguagesByTheSDK() {
+        List<Locale> langs = new ArrayList<>();
+        langs.add(new Locale("en", ""));
+        langs.add(new Locale("ar", ""));
+        langs.add(new Locale("de", ""));
+        langs.add(new Locale("es", ""));
+        langs.add(new Locale("fr", ""));
+        langs.add(new Locale("it", ""));
+        langs.add(new Locale("ja", ""));
+        langs.add(new Locale("ko", ""));
+        langs.add(new Locale("pl", ""));
+        langs.add(new Locale("pt", "BR"));
+        langs.add(new Locale("pt", "PT"));
+        langs.add(new Locale("ru", ""));
+        langs.add(new Locale("sv", ""));
+        langs.add(new Locale("tr", ""));
+        langs.add(new Locale("zh", "CN"));
+        langs.add(new Locale("zh", "TW"));
+        langs.add(new Locale("cs", ""));
+        langs.add(new Locale("fa", ""));
+        langs.add(new Locale("in", ""));
+        langs.add(new Locale("da", ""));
+        langs.add(new Locale("sk", ""));
+        langs.add(new Locale("nl", ""));
+        langs.add(new Locale("no", ""));
+        return langs;
+    }
+}

--- a/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
@@ -44,14 +44,12 @@ public class ArgsRegistryTest {
         // when
         ArgsRegistry.registerLocaleArgs(map);
         // then
-        //TODO fix missing locales
         assertAllSupportedLocalesArePresent(map);
     }
 
     @Test
     public void given$ArgsRegistryIsInitialized_whenQuery_thenShouldMatchCriteria() {
         Map<String, Object> args = ArgsRegistry.ARGS;
-        //TODO fix missing invocation mode and missing locales
         assertAllInvocationEventsArePresent(args);
         assertAllWelcomeMessageStatesArePresent(args);
         assertAllSupportedLocalesArePresent(args);
@@ -117,7 +115,9 @@ public class ArgsRegistryTest {
         // actual
         List<Locale> actualLocales = new ArrayList<>();
         for (Map.Entry m : map.entrySet()) {
-            actualLocales.add((Locale) m.getValue());
+            if (m.getValue() instanceof Locale) {
+                actualLocales.add((Locale) m.getValue());
+            }
         }
         StringBuilder stringBuilder = new StringBuilder();
         for (Locale expectedLocale : expectedLocales) {
@@ -159,7 +159,6 @@ public class ArgsRegistryTest {
         langs.add(new Locale("zh", "CN"));
         langs.add(new Locale("zh", "TW"));
         langs.add(new Locale("cs", ""));
-        langs.add(new Locale("fa", ""));
         langs.add(new Locale("in", ""));
         langs.add(new Locale("da", ""));
         langs.add(new Locale("sk", ""));

--- a/lib/instabug_flutter.dart
+++ b/lib/instabug_flutter.dart
@@ -27,10 +27,14 @@ enum Locale {
   Korean,
   Polish,
   PortugueseBrazil,
+  PortuguesePortugal,
   Russian,
   Spanish,
   Swedish,
-  Turkish
+  Turkish,
+  Indonesian,
+  Slovak,
+  Norwegian
 }
 
 enum ColorTheme { dark, light }


### PR DESCRIPTION
## Summary
Converted the `InstabugFlutterPlugin.getConstants()` to a registry for easier code maintenance and unit testing.

## Change log
- Modified `Instabug-Flutter/android/build.gradle` (added [junit4](https://junit.org/junit4/) dependency)
- Added `ArgsRegistry`
- Added `ArgsRegistryTest`
- Modified `InstabugFlutterPlugin` (Removed unused imports, replaced deprecated API and replaced all `getConstants()` calls with `ArgsRegistry`)
- Reformatted code [`InstabugFlutterPlugin` & `ArgsRegistry`]
- Added missing languages [`PortuguesePortugal`, `Indonesian`, `Slovak` and `Norwegian`]

## Happy scenarios passed
- [x] App builds with no errors
- [x] All unit tests pass