### PR TITLE
Treats lint warnings as errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
       - run: bundle exec danger
       - run: flutter doctor
       - run: pub get
-      - run: dartanalyzer --options analysis_options.yaml lib
+      - run: dartanalyzer --options analysis_options.yaml --fatal-warnings lib


### PR DESCRIPTION
For now, treats all warnings as errors, until we figure out which of them we actually care about.