### PR TITLE
Feature - Add shaking threshold APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* Adds setShakingThresholdForiPhone, setShakingThresholdForiPad and setShakingThresholdForAndroid APIs
+
 ## v9.1.0 (2020-03-19)
 
 * Bump Native SDKs to v9.1

--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -861,4 +861,15 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
             networkLog.insert();
     }
 
+    /**
+     * Sets the threshold value of the shake gesture for android devices.
+     * Default for android is an integer value equals 350.
+     * you could increase the shaking difficulty level by
+     * increasing the `350` value and vice versa
+     * @param androidThreshold Threshold for android devices.
+     */
+    public void setShakingThresholdForAndroid(int androidThreshold) {
+        BugReporting.setShakingThreshold(androidThreshold);
+    }
+
 }

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -693,6 +693,28 @@ FlutterMethodChannel* channel;
    IBGReplies.inAppNotificationsEnabled = boolValue;
 }
 
+
+/**
+ * Sets the threshold value of the shake gesture for iPhone/iPod Touch
+ * Default for iPhone is 2.5.
+ * @param  iPhoneShakingThreshold Threshold for iPhone.
+ */
++ (void)setShakingThresholdForiPhone:(NSNumber *)iPhoneShakingThreshold {
+    double threshold = [iPhoneShakingThreshold doubleValue];
+    IBGBugReporting.shakingThresholdForiPhone = threshold;
+
+}
+
+/**
+ * Sets the threshold value of the shake gesture for iPad.
+ * Default for iPad is 0.6.
+ * @param iPadShakingThreshold Threshold for iPad.
+ */
++ (void)setShakingThresholdForiPad:(NSNumber *)iPadShakingThreshold {
+    double threshold = [iPadShakingThreshold doubleValue];
+    IBGBugReporting.shakingThresholdForiPad = threshold;
+}
+
 /**
  * Extracts HTTP connection properties. Request method, Headers, Date, Url and Response code
  *

--- a/lib/BugReporting.dart
+++ b/lib/BugReporting.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:instabug_flutter/Instabug.dart';
 
@@ -187,5 +188,41 @@ class BugReporting {
     ];
     await _channel.invokeMethod<Object>(
         'showBugReportingWithReportTypeAndOptions:options:', params);
+  }
+
+  /// Sets the threshold value of the shake gesture for iPhone/iPod Touch
+  /// Default for iPhone is 2.5.
+  /// [iPhoneShakingThreshold] iPhoneShakingThreshold double
+  static void setShakingThresholdForiPhone(
+      double iPhoneShakingThreshold) async {
+    if (Platform.isIOS) {
+      final List<dynamic> params = <dynamic>[iPhoneShakingThreshold];
+      await _channel.invokeMethod<Object>(
+          'setShakingThresholdForiPhone:', params);
+    }
+  }
+
+  /// Sets the threshold value of the shake gesture for iPad
+  /// Default for iPhone is 0.6.
+  /// [iPadShakingThreshold] iPhoneShakingThreshold double
+  static void setShakingThresholdForiPad(double iPadShakingThreshold) async {
+    if (Platform.isIOS) {
+      final List<dynamic> params = <dynamic>[iPadShakingThreshold];
+      await _channel.invokeMethod<Object>(
+          'setShakingThresholdForiPad:', params);
+    }
+  }
+
+  /// Sets the threshold value of the shake gesture for android devices.
+  /// Default for android is an integer value equals 350.
+  /// you could increase the shaking difficulty level by
+  /// increasing the `350` value and vice versa
+  /// [androidThreshold] iPhoneShakingThreshold int
+  static void setShakingThresholdForAndroid(int androidThreshold) async {
+    if (Platform.isAndroid) {
+      final List<dynamic> params = <dynamic>[androidThreshold];
+      await _channel.invokeMethod<Object>(
+          'setShakingThresholdForAndroid:', params);
+    }
   }
 }


### PR DESCRIPTION
## Summary of Changes

* Adds `setShakingThresholdForiPhone`, `setShakingThresholdForiPad` and `setShakingThresholdForAndroid` APIs
* Fixes #125 

## Checklist
- [x] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [ ] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally. ( Skipped, because the APIs contain platform specific calls that would fail in unit test )
