### PR TITLE
Add .flutter-plugins-dependencies to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ lint/tmp/
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+example/.flutter-plugins-dependencies


### PR DESCRIPTION
## Summary of Changes

Adds .flutter-plugins-dependencies to .gitignore

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [X] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [X] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [X] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
