### PR TITLE
Feature/Add setSdkDebugLogsLevel iOS API

### DIFF
--- a/ios/Classes/InstabugFlutterPlugin.h
+++ b/ios/Classes/InstabugFlutterPlugin.h
@@ -45,6 +45,14 @@
 + (void)setLocale:(NSString *)locale;
 
 /**
+  * This API sets the verbosity level of logs used to debug The SDK. The defualt value in debug 
+  * mode is sdkDebugLogsLevelVerbose and in production is sdkDebugLogsLevelError.
+  *
+  * @param sdkDebugLogsLevel
+  */
++ (void)setSdkDebugLogsLevel:(NSString *)sdkDebugLogsLevel;
+
+/**
   * Appends a log message to Instabug internal log
   * These logs are then sent along the next uploaded report.
   * All log messages are timestamped 

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -131,6 +131,18 @@ FlutterMethodChannel* channel;
 }
 
 /**
+  * This API sets the verbosity level of logs used to debug The SDK. The defualt value in debug 
+  * mode is sdkDebugLogsLevelVerbose and in production is sdkDebugLogsLevelError.
+  *
+  * @param sdkDebugLogsLevel
+  */
++ (void)setSdkDebugLogsLevel:(NSString *)sdkDebugLogsLevel {
+    NSDictionary *constants = [self constants];
+    NSInteger sdkDebugLogsLevelInt = ((NSNumber *) constants[sdkDebugLogsLevel]).integerValue;
+    [Instabug setSdkDebugLogsLevel:sdkDebugLogsLevelInt];
+}
+
+/**
   * Appends a log message to Instabug internal log
   * These logs are then sent along the next uploaded report.
   * All log messages are timestamped 
@@ -868,6 +880,11 @@ FlutterMethodChannel* channel;
       @"IBGLocale.spanish": @(IBGLocaleSpanish),
       @"IBGLocale.swedish": @(IBGLocaleSwedish),
       @"IBGLocale.turkish": @(IBGLocaleTurkish),
+
+      @"IBGSDKDebugLogsLevel.verbose": @(IBGSDKDebugLogsLevelVerbose),
+      @"IBGSDKDebugLogsLevel.debug": @(IBGSDKDebugLogsLevelDebug),
+      @"IBGSDKDebugLogsLevel.error": @(IBGSDKDebugLogsLevelError),
+      @"IBGSDKDebugLogsLevel.none": @(IBGSDKDebugLogsLevelNone),
       
       @"CustomTextPlaceHolderKey.shakeHint": kIBGShakeStartAlertTextStringName,
       @"CustomTextPlaceHolderKey.swipeHint": kIBGEdgeSwipeStartAlertTextStringName,

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -44,6 +44,8 @@ enum IBGLocale {
   norwegian
 }
 
+enum IBGSDKDebugLogsLevel { verbose, debug, error, none }
+
 enum ColorTheme { dark, light }
 
 enum CustomTextPlaceHolderKey {
@@ -142,6 +144,14 @@ class Instabug {
   static Future<void> setLocale(IBGLocale locale) async {
     final List<dynamic> params = <dynamic>[locale.toString()];
     await _channel.invokeMethod<Object>('setLocale:', params);
+  }
+
+  /// Sets the verbosity level of logs used to debug The SDK. The defualt value in debug
+  /// mode is sdkDebugLogsLevelVerbose and in production is sdkDebugLogsLevelError.
+  static void setSdkDebugLogsLevel(
+      IBGSDKDebugLogsLevel sdkDebugLogsLevel) async {
+    final List<dynamic> params = <dynamic>[sdkDebugLogsLevel.toString()];
+    await _channel.invokeMethod<Object>('setSdkDebugLogsLevel:', params);
   }
 
   /// Sets the color theme of the SDK's whole UI to the [colorTheme] given.

--- a/test/instabug_flutter_test.dart
+++ b/test/instabug_flutter_test.dart
@@ -165,6 +165,19 @@ void main() {
     ]);
   });
 
+  test('setSdkDebugLogsLevel:', () async {
+    Instabug.setSdkDebugLogsLevel(IBGSDKDebugLogsLevel.verbose);
+    final List<dynamic> args = <dynamic>[
+      IBGSDKDebugLogsLevel.verbose.toString()
+    ];
+    expect(log, <Matcher>[
+      isMethodCall(
+        'setSdkDebugLogsLevel:',
+        arguments: args,
+      )
+    ]);
+  });
+
   test('logVerbose: Test', () async {
     InstabugLog.logVerbose(message);
     final List<dynamic> args = <dynamic>[message];


### PR DESCRIPTION
## Summary of Changes
Added setSdkDebugLogsLevel iOS API.

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [X] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [X] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [X] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
