### PR TITLE
Fixed NPE in Observer when we don't have previous page

### DIFF
--- a/lib/InstabugNavigatorObserver.dart
+++ b/lib/InstabugNavigatorObserver.dart
@@ -29,7 +29,9 @@ class InstabugNavigatorObserver extends NavigatorObserver {
 
   @override
   void didPop(Route route, Route previousRoute) {
-    screenChanged(previousRoute);
+    if (previousRoute != null) {
+      screenChanged(previousRoute);
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary of Changes


Fixed Case: 
1) You stay on first sceen in app 
2) Call `Navigator.pushNamedAndRemoveUntil`
3) Have nullable previosPage 
