### PR TITLE
Fix invocation events value passed to native SDK

### DIFF
--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -68,9 +68,12 @@ FlutterMethodChannel* channel;
     }
 
     NSDictionary *constants = [self constants];
-    NSInteger invocationEvents = IBGInvocationEventNone;
+    NSInteger invocationEvents = 0;
     for (NSString * invocationEvent in invocationEventsArray) {
         invocationEvents |= ((NSNumber *) constants[invocationEvent]).integerValue;
+    }
+    if (invocationEvents == 0) {
+      invocationEvents = IBGInvocationEventNone;
     }
     [Instabug startWithToken:token invocationEvents:invocationEvents];
 }


### PR DESCRIPTION
## Summary of Changes

- Fixes the welcome message invocation by setting a default value of 0 instead of `IBGInvocationEventNone` which encapsulates a value of `16`.

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [ ] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [ ] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [ ] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
