### PR TITLE
[INSD-5205] Feature/Add replies notification string keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+* Adds mapping for the replies notification string keys.
+
 ## v9.1.8 (2021-02-17)
 
 * Fixes an issue with iOS invocation events causing the welcome message not to show.

--- a/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
@@ -189,6 +189,9 @@ final class ArgsRegistry {
         args.put("CustomTextPlaceHolderKey.betaWelcomeMessageFinishStepContent", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_CONTENT);
         args.put("CustomTextPlaceHolderKey.liveWelcomeMessageTitle", InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_TITLE);
         args.put("CustomTextPlaceHolderKey.liveWelcomeMessageContent", InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_CONTENT);
+        args.put("CustomTextPlaceHolderKey.repliesNotificationTeamName", InstabugCustomTextPlaceHolder.Key.CHATS_TEAM_STRING_NAME);
+        args.put("CustomTextPlaceHolderKey.repliesNotificationReplyButton", InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
+        args.put("CustomTextPlaceHolderKey.repliesNotificationDismissButton", InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
     }
 
     static void registerInstabugReportTypesArgs(Map<String, Object> args) {

--- a/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
@@ -283,6 +283,9 @@ public class ArgsRegistryTest {
         keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_CONTENT);
         keys.add(InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_TITLE);
         keys.add(InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_CONTENT);
+        keys.add(InstabugCustomTextPlaceHolder.Key.CHATS_TEAM_STRING_NAME);
+        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
+        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
         return keys;
     }
 
@@ -329,6 +332,9 @@ public class ArgsRegistryTest {
         keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_WELCOME_SCREEN_SUBTITLE);
         keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_WELCOME_SCREEN_BUTTON);
         keys.add(InstabugCustomTextPlaceHolder.Key.REQUEST_FEATURE);
+        keys.add(InstabugCustomTextPlaceHolder.Key.CHATS_TEAM_STRING_NAME);
+        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
+        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
         return keys;
     }
 }

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -900,6 +900,10 @@ FlutterMethodChannel* channel;
       @"CustomTextPlaceHolderKey.liveWelcomeMessageTitle": kIBGLiveWelcomeMessageTitle,
       @"CustomTextPlaceHolderKey.liveWelcomeMessageContent": kIBGLiveWelcomeMessageContent,
 
+      @"CustomTextPlaceHolderKey.repliesNotificationTeamName": kIBGTeamStringName,
+      @"CustomTextPlaceHolderKey.repliesNotificationReplyButton": kIBGReplyButtonTitleStringName,
+      @"CustomTextPlaceHolderKey.repliesNotificationDismissButton": kIBGDismissButtonTitleStringName,
+
       @"ReportType.bug": @(IBGBugReportingReportTypeBug),
       @"ReportType.feedback": @(IBGBugReportingReportTypeFeedback),
       @"ReportType.question": @(IBGBugReportingReportTypeQuestion),

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -76,7 +76,10 @@ enum CustomTextPlaceHolderKey {
   betaWelcomeMessageFinishStepTitle,
   betaWelcomeMessageFinishStepContent,
   liveWelcomeMessageTitle,
-  liveWelcomeMessageContent
+  liveWelcomeMessageContent,
+  repliesNotificationTeamName,
+  repliesNotificationReplyButton,
+  repliesNotificationDismissButton
 }
 
 enum ReproStepsMode { enabled, disabled, enabledWithNoScreenshots }


### PR DESCRIPTION
## Summary of Changes

Add the string keys for the Replies notification:
- `CustomTextPlaceHolderKey.repliesNotificationTeamName`
- `CustomTextPlaceHolderKey.repliesNotificationReplyButton`
- `CustomTextPlaceHolderKey.repliesNotificationDismissButton`

## iOS
![Simulator Screen Shot - iPhone 11 - 2021-03-26 at 16 08 56](https://user-images.githubusercontent.com/10587548/112655574-35285000-8e59-11eb-94b2-edc81001d8ae.png)

## Android
<img width="476" alt="Screen Shot 2021-03-26 at 16 22 18" src="https://user-images.githubusercontent.com/10587548/112655582-36f21380-8e59-11eb-9394-4db725f191e9.png">


<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [X] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [X] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [ ] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
