### PR TITLE
[MOB-4686] Feature/add setDebugEnabled Android API

### DIFF
--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -423,6 +423,15 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
     }
 
     /**
+     * Enable/disable SDK logs
+     *
+     * @param debugEnabled desired state of debug mode
+     */
+    public void setDebugEnabled(boolean debugEnabled) {
+        Instabug.setDebugEnabled(debugEnabled);
+    }
+
+    /**
      * Set the primary color that the SDK will use to tint certain UI elements in
      * the SDK
      *

--- a/example/android/app/src/main/kotlin/com/example/InstabugSample/OnMethodCallTests.java
+++ b/example/android/app/src/main/kotlin/com/example/InstabugSample/OnMethodCallTests.java
@@ -99,6 +99,15 @@ class OnMethodCallTests {
         verify(instabugMock).setSessionProfilerEnabled(true);
     }
 
+    public void testSetDebugEnabled() {
+        String methodName = "setDebugEnabled";
+        ArrayList<Object> argsList = new ArrayList<>();
+        argsList.add(true);
+        Mockito.doNothing().when(instabugMock).setDebugEnabled(any(Boolean.class));
+        testMethodCall(methodName,argsList);
+        verify(instabugMock).setDebugEnabled(true);
+    }
+
     public void testSetPrimaryColor() {
         String methodName = "setPrimaryColor";
         ArrayList<Object> argsList = new ArrayList<>();

--- a/example/android/app/src/test/java/com/example/InstabugSample/InstabugFlutterPluginTest.java
+++ b/example/android/app/src/test/java/com/example/InstabugSample/InstabugFlutterPluginTest.java
@@ -58,6 +58,14 @@ public class InstabugFlutterPluginTest {
     }
 
     /**
+     * (boolean)
+     */
+    @Test
+    public void testSetDebugEnabled() {
+        new OnMethodCallTests().testSetDebugEnabled();
+    }
+
+    /**
      * (long)
      */
     @Test

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -225,6 +225,16 @@ class Instabug {
     await _channel.invokeMethod<Object>('setSessionProfilerEnabled:', params);
   }
 
+  /// Android only
+  /// Enable/disable SDK logs
+  /// [debugEnabled] desired state of debug mode.
+  static void setDebugEnabled(bool debugEnabled) async {
+    if (PlatformManager.instance.isAndroid()) {
+      final List<dynamic> params = <dynamic>[debugEnabled];
+      await _channel.invokeMethod<Object>('setDebugEnabled:', params);
+    }
+  }
+
   /// Sets the primary color of the SDK's UI.
   /// Sets the color of UI elements indicating interactivity or call to action.
   /// [color] primaryColor A color to set the UI elements of the SDK to.

--- a/test/instabug_flutter_test.dart
+++ b/test/instabug_flutter_test.dart
@@ -358,6 +358,20 @@ void main() {
     ]);
   });
 
+  test('setDebugEnabled: Test', () async {
+    when(mockPlatform.isAndroid()).thenAnswer((_) => true);
+
+    const bool debugEnabled = true;
+    final List<dynamic> args = <dynamic>[debugEnabled];
+    Instabug.setDebugEnabled(debugEnabled);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'setDebugEnabled:',
+        arguments: args,
+      )
+    ]);
+  });
+
   test('setPrimaryColor: Test', () async {
     const c = Color.fromRGBO(255, 0, 255, 1.0);
     final List<dynamic> args = <dynamic>[c.value];


### PR DESCRIPTION
## Summary of Changes
- Added setDebugEnabled API to enable/disable the Instabug debug logs.
- API added for Android only
- Unit test added to java test files only

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [ ] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [ ] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [ ] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
