### PR TITLE
Call return handler for void methods on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## v9.1.8 (2021-02-17)
 
 * Fixes an issue with iOS invocation events causing the welcome message not to show.
+* Change all `void ... async` methods to `Future<void> ... async` so that callers can use `await`.
 
 ## v9.1.7 (2020-10-01)
 

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -39,10 +39,12 @@ FlutterMethodChannel* channel;
           const char *type = [signature methodReturnType];
 
           if (strcmp(type, "v") != 0) {
-              void *returnVal;
+            void *returnVal;
             [inv getReturnValue:&returnVal];
             NSObject *resultSet = (__bridge NSObject *)returnVal;
             result(resultSet);
+          } else {
+            result(nil);
           }
       }
     if (!isImplemented) {

--- a/lib/BugReporting.dart
+++ b/lib/BugReporting.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+
 import 'package:flutter/services.dart';
 import 'package:instabug_flutter/Instabug.dart';
 
@@ -74,7 +75,7 @@ class BugReporting {
 
   ///Enables and disables manual invocation and prompt options for bug and feedback.
   /// [boolean] isEnabled
-  static void setEnabled(bool isEnabled) async {
+  static Future<void> setEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>('setBugReportingEnabled:', params);
   }
@@ -83,7 +84,7 @@ class BugReporting {
   /// This block is executed on the UI thread. Could be used for performing any
   /// UI changes before the SDK's UI is shown.
   /// [function]  A callback that gets executed before invoking the SDK
-  static void setOnInvokeCallback(Function function) async {
+  static Future<void> setOnInvokeCallback(Function function) async {
     _channel.setMethodCallHandler(_handleMethod);
     _onInvokeCallback = function;
     await _channel.invokeMethod<Object>('setOnInvokeCallback');
@@ -93,7 +94,7 @@ class BugReporting {
   /// This block is executed on the UI thread. Could be used for performing any
   /// UI changes before the SDK's UI is shown.
   /// [function]  A callback that gets executed before invoking the SDK
-  static void setOnDismissCallback(Function function) async {
+  static Future<void> setOnDismissCallback(Function function) async {
     _channel.setMethodCallHandler(_handleMethod);
     _onDismissCallback = function;
     await _channel.invokeMethod<Object>('setOnDismissCallback');
@@ -102,7 +103,7 @@ class BugReporting {
   /// Sets the events that invoke the feedback form.
   /// Default is set by `Instabug.startWithToken`.
   /// [invocationEvents] invocationEvent List of events that invokes the
-  static void setInvocationEvents(
+  static Future<void> setInvocationEvents(
       List<InvocationEvent> invocationEvents) async {
     final List<String> invocationEventsStrings = <String>[];
     if (invocationEvents != null) {
@@ -121,8 +122,8 @@ class BugReporting {
   /// attachments. In iOS 10+,NSPhotoLibraryUsageDescription should be set in
   /// info.plist to enable gallery image attachments.
   /// [screenRecording] A boolean to enable or disable screen recording attachments.
-  static void setEnabledAttachmentTypes(bool screenshot, bool extraScreenshot,
-      bool galleryImage, bool screenRecording) async {
+  static Future<void> setEnabledAttachmentTypes(bool screenshot,
+      bool extraScreenshot, bool galleryImage, bool screenRecording) async {
     final List<dynamic> params = <dynamic>[
       screenshot,
       extraScreenshot,
@@ -136,7 +137,7 @@ class BugReporting {
 
   ///Sets what type of reports, bug or feedback, should be invoked.
   /// [reportTypes] - List of reportTypes
-  static void setReportTypes(List<ReportType> reportTypes) async {
+  static Future<void> setReportTypes(List<ReportType> reportTypes) async {
     final List<String> reportTypesStrings = <String>[];
     if (reportTypes != null) {
       reportTypes.forEach((e) {
@@ -150,7 +151,7 @@ class BugReporting {
   /// Sets whether the extended bug report mode should be disabled, enabled with
   /// required fields or enabled with optional fields.
   /// [extendedBugReportMode] ExtendedBugReportMode enum
-  static void setExtendedBugReportMode(
+  static Future<void> setExtendedBugReportMode(
       ExtendedBugReportMode extendedBugReportMode) async {
     final List<dynamic> params = <dynamic>[extendedBugReportMode.toString()];
     await _channel.invokeMethod<Object>('setExtendedBugReportMode:', params);
@@ -159,7 +160,7 @@ class BugReporting {
   /// Sets the invocation options.
   /// Default is set by `Instabug.startWithToken`.
   /// [invocationOptions] List of invocation options
-  static void setInvocationOptions(
+  static Future<void> setInvocationOptions(
       List<InvocationOption> invocationOptions) async {
     final List<String> invocationOptionsStrings = <String>[];
     if (invocationOptions != null) {
@@ -174,7 +175,7 @@ class BugReporting {
   /// Invoke bug reporting with report type and options.
   /// [reportType] type
   /// [invocationOptions]  List of invocation options
-  static void show(
+  static Future<void> show(
       ReportType reportType, List<InvocationOption> invocationOptions) async {
     final List<String> invocationOptionsStrings = <String>[];
     if (invocationOptions != null) {
@@ -193,7 +194,7 @@ class BugReporting {
   /// Sets the threshold value of the shake gesture for iPhone/iPod Touch
   /// Default for iPhone is 2.5.
   /// [iPhoneShakingThreshold] iPhoneShakingThreshold double
-  static void setShakingThresholdForiPhone(
+  static Future<void> setShakingThresholdForiPhone(
       double iPhoneShakingThreshold) async {
     if (Platform.isIOS) {
       final List<dynamic> params = <dynamic>[iPhoneShakingThreshold];
@@ -205,7 +206,8 @@ class BugReporting {
   /// Sets the threshold value of the shake gesture for iPad
   /// Default for iPhone is 0.6.
   /// [iPadShakingThreshold] iPhoneShakingThreshold double
-  static void setShakingThresholdForiPad(double iPadShakingThreshold) async {
+  static Future<void> setShakingThresholdForiPad(
+      double iPadShakingThreshold) async {
     if (Platform.isIOS) {
       final List<dynamic> params = <dynamic>[iPadShakingThreshold];
       await _channel.invokeMethod<Object>(
@@ -218,7 +220,8 @@ class BugReporting {
   /// you could increase the shaking difficulty level by
   /// increasing the `350` value and vice versa
   /// [androidThreshold] iPhoneShakingThreshold int
-  static void setShakingThresholdForAndroid(int androidThreshold) async {
+  static Future<void> setShakingThresholdForAndroid(
+      int androidThreshold) async {
     if (Platform.isAndroid) {
       final List<dynamic> params = <dynamic>[androidThreshold];
       await _channel.invokeMethod<Object>(

--- a/lib/Chats.dart
+++ b/lib/Chats.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 class Chats {
@@ -8,19 +9,21 @@ class Chats {
     final String version = await _channel.invokeMethod('getPlatformVersion');
     return version;
   }
-  
+
   @deprecated
+
   ///Use {@link BugReporting.show} instead.
   ///Manual invocation for chats view.
-  static void show() async {
+  static Future<void> show() async {
     await _channel.invokeMethod<Object>('showChats');
   }
 
   @deprecated
+
   ///Use {@link BugReporting.setReportTypes} instead.
   /// Enables and disables everything related to creating new chats.
   /// [boolean] isEnabled
-  static void setEnabled(bool isEnabled) async {
+  static Future<void> setEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>('setChatsEnabled:', params);
   }

--- a/lib/CrashReporting.dart
+++ b/lib/CrashReporting.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform, exit;
-import 'package:flutter/services.dart';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:instabug_flutter/models/crash_data.dart';
 import 'package:instabug_flutter/models/exception_data.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -17,13 +18,13 @@ class CrashReporting {
 
   ///Enables and disables Enables and disables automatic crash reporting.
   /// [boolean] isEnabled
-  static void setEnabled(bool isEnabled) async {
+  static Future<void> setEnabled(bool isEnabled) async {
     enabled = isEnabled;
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>('setCrashReportingEnabled:', params);
   }
 
-  static void reportCrash(dynamic exception, StackTrace stack) async {
+  static Future<void> reportCrash(dynamic exception, StackTrace stack) async {
     if (kReleaseMode && enabled) {
       _reportUnhandledCrash(exception, stack);
     } else {
@@ -35,7 +36,8 @@ class CrashReporting {
   /// Reports a handled crash to you dashboard
   /// [dynamic] exception
   /// [StackTrace] stack
-  static void reportHandledCrash(dynamic exception, [StackTrace stack]) async {
+  static Future<void> reportHandledCrash(dynamic exception,
+      [StackTrace stack]) async {
     if (stack != null) {
       _sendCrash(exception, stack, true);
     } else {
@@ -43,11 +45,12 @@ class CrashReporting {
     }
   }
 
-  static void _reportUnhandledCrash(dynamic exception, StackTrace stack) async {
+  static Future<void> _reportUnhandledCrash(
+      dynamic exception, StackTrace stack) async {
     _sendCrash(exception, stack, false);
   }
 
-  static void _sendCrash(
+  static Future<void> _sendCrash(
       dynamic exception, StackTrace stack, bool handled) async {
     final Trace trace = Trace.from(stack);
     final List<ExceptionData> frames = <ExceptionData>[];

--- a/lib/FeatureRequests.dart
+++ b/lib/FeatureRequests.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
+
 import 'package:flutter/services.dart';
 
-enum ActionType {
-  requestNewFeature,
-  addCommentToFeature
-}
+enum ActionType { requestNewFeature, addCommentToFeature }
 
 class FeatureRequests {
   static const MethodChannel _channel = MethodChannel('instabug_flutter');
@@ -15,7 +13,7 @@ class FeatureRequests {
   }
 
   ///Shows the UI for feature requests list
-  static void show() async {
+  static Future<void> show() async {
     await _channel.invokeMethod<Object>('showFeatureRequests');
   }
 
@@ -24,7 +22,7 @@ class FeatureRequests {
   /// [isEmailFieldRequired] A boolean to indicate whether email
   /// field is required or not.
   /// [actionTypes] An enum that indicates which action types will have the isEmailFieldRequired
-  static void setEmailFieldRequired(
+  static Future<void> setEmailFieldRequired(
       bool isEmailFieldRequired, List<ActionType> actionTypes) async {
     final List<String> actionTypesStrings = <String>[];
     if (actionTypes != null) {

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 import 'dart:typed_data';
 import 'dart:ui';
+
 import 'package:flutter/services.dart';
 
 enum InvocationEvent {
@@ -99,7 +100,7 @@ class Instabug {
   /// it on your dashboard.
   /// The [invocationEvents] are the events that invoke
   /// the SDK's UI.
-  static void start(
+  static Future<void> start(
       String token, List<InvocationEvent> invocationEvents) async {
     final List<String> invocationEventsStrings = <String>[];
     invocationEvents.forEach((e) {
@@ -112,7 +113,7 @@ class Instabug {
 
   /// Shows the welcome message in a specific mode.
   /// [welcomeMessageMode] is an enum to set the welcome message mode to live, or beta.
-  static void showWelcomeMessageWithMode(
+  static Future<void> showWelcomeMessageWithMode(
       WelcomeMessageMode welcomeMessageMode) async {
     final List<dynamic> params = <dynamic>[welcomeMessageMode.toString()];
     await _channel.invokeMethod<Object>('showWelcomeMessageWithMode:', params);
@@ -122,7 +123,7 @@ class Instabug {
   /// and set the user's [name] to be included with all reports.
   /// It also reset the chats on device to that email and removes user attributes,
   /// user data and completed surveys.
-  static void identifyUser(String email, [String name]) async {
+  static Future<void> identifyUser(String email, [String name]) async {
     final List<dynamic> params = <dynamic>[email, name];
     await _channel.invokeMethod<Object>('identifyUserWithEmail:name:', params);
   }
@@ -130,33 +131,33 @@ class Instabug {
   /// Sets the default value of the user's email to nil and show email field and remove user name
   /// from all reports
   /// It also reset the chats on device and removes user attributes, user data and completed surveys.
-  static void logOut() async {
+  static Future<void> logOut() async {
     await _channel.invokeMethod<Object>('logOut');
   }
 
   /// Sets the SDK's [locale].
   /// Use to change the SDK's UI to different language.
   /// Defaults to the device's current locale.
-  static void setLocale(IBGLocale locale) async {
+  static Future<void> setLocale(IBGLocale locale) async {
     final List<dynamic> params = <dynamic>[locale.toString()];
     await _channel.invokeMethod<Object>('setLocale:', params);
   }
 
   /// Sets the color theme of the SDK's whole UI to the [colorTheme] given.
   /// It should be of type [ColorTheme].
-  static void setColorTheme(ColorTheme colorTheme) async {
+  static Future<void> setColorTheme(ColorTheme colorTheme) async {
     final List<dynamic> params = <dynamic>[colorTheme.toString()];
     await _channel.invokeMethod<Object>('setColorTheme:', params);
   }
 
   /// Appends a set of [tags] to previously added tags of reported feedback, bug or crash.
-  static void appendTags(List<String> tags) async {
+  static Future<void> appendTags(List<String> tags) async {
     final List<dynamic> params = <dynamic>[tags];
     await _channel.invokeMethod<Object>('appendTags:', params);
   }
 
   /// Manually removes all tags of reported feedback, bug or crash.
-  static void resetTags() async {
+  static Future<void> resetTags() async {
     await _channel.invokeMethod<Object>('resetTags');
   }
 
@@ -167,14 +168,14 @@ class Instabug {
   }
 
   /// Add custom user attribute [value] with a [key] that is going to be sent with each feedback, bug or crash.
-  static void setUserAttribute(String value, String key) async {
+  static Future<void> setUserAttribute(String value, String key) async {
     final List<dynamic> params = <dynamic>[value, key];
     await _channel.invokeMethod<Object>('setUserAttribute:withKey:', params);
   }
 
   /// Removes a given [key] and its associated value from user attributes.
   /// Does nothing if a [key] does not exist.
-  static void removeUserAttribute(String key) async {
+  static Future<void> removeUserAttribute(String key) async {
     final List<dynamic> params = <dynamic>[key];
     await _channel.invokeMethod<Object>('removeUserAttributeForKey:', params);
   }
@@ -196,20 +197,20 @@ class Instabug {
   }
 
   /// invoke sdk manually
-  static void show() async {
+  static Future<void> show() async {
     await _channel.invokeMethod<Object>('show');
   }
 
   /// Logs a user event with [name] that happens through the lifecycle of the application.
   /// Logged user events are going to be sent with each report, as well as at the end of a session.
-  static void logUserEvent(String name) async {
+  static Future<void> logUserEvent(String name) async {
     final List<String> params = <String>[name];
     await _channel.invokeMethod<Object>('logUserEventWithName:', params);
   }
 
   /// Overrides any of the strings shown in the SDK with custom ones.
   /// Allows you to customize a [value] shown to users in the SDK using a predefined [key].
-  static void setValueForStringWithKey(
+  static Future<void> setValueForStringWithKey(
       String value, CustomTextPlaceHolderKey key) async {
     final List<dynamic> params = <dynamic>[value, key.toString()];
     await _channel.invokeMethod<Object>('setValue:forStringWithKey:', params);
@@ -217,7 +218,8 @@ class Instabug {
 
   /// Enable/disable session profiler
   /// [sessionProfilerEnabled] desired state of the session profiler feature.
-  static void setSessionProfilerEnabled(bool sessionProfilerEnabled) async {
+  static Future<void> setSessionProfilerEnabled(
+      bool sessionProfilerEnabled) async {
     final List<dynamic> params = <dynamic>[sessionProfilerEnabled];
     await _channel.invokeMethod<Object>('setSessionProfilerEnabled:', params);
   }
@@ -225,14 +227,14 @@ class Instabug {
   /// Sets the primary color of the SDK's UI.
   /// Sets the color of UI elements indicating interactivity or call to action.
   /// [color] primaryColor A color to set the UI elements of the SDK to.
-  static void setPrimaryColor(Color color) async {
+  static Future<void> setPrimaryColor(Color color) async {
     final List<dynamic> params = <dynamic>[color.value];
     await _channel.invokeMethod<Object>('setPrimaryColor:', params);
   }
 
   /// Adds specific user data that you need to be added to the reports
   /// [userData] data to be added
-  static void setUserData(String userData) async {
+  static Future<void> setUserData(String userData) async {
     final List<dynamic> params = <dynamic>[userData];
     await _channel.invokeMethod<Object>('setUserData:', params);
   }
@@ -240,7 +242,8 @@ class Instabug {
   ///Add file to be attached to the bug report.
   ///[filePath] of the file
   ///[fileName] of the file
-  static void addFileAttachmentWithURL(String filePath, String fileName) async {
+  static Future<void> addFileAttachmentWithURL(
+      String filePath, String fileName) async {
     if (Platform.isIOS) {
       final List<dynamic> params = <dynamic>[filePath];
       await _channel.invokeMethod<Object>('addFileAttachmentWithURL:', params);
@@ -253,7 +256,8 @@ class Instabug {
   ///Add file to be attached to the bug report.
   ///[data] of the file
   ///[fileName] of the file
-  static void addFileAttachmentWithData(Uint8List data, String fileName) async {
+  static Future<void> addFileAttachmentWithData(
+      Uint8List data, String fileName) async {
     if (Platform.isIOS) {
       final List<dynamic> params = <dynamic>[data];
       await _channel.invokeMethod<Object>('addFileAttachmentWithData:', params);
@@ -265,13 +269,13 @@ class Instabug {
 
   ///Clears all Uris of the attached files.
   ///The URIs which added via {@link Instabug#addFileAttachment} API not the physical files.
-  static void clearFileAttachments() async {
+  static Future<void> clearFileAttachments() async {
     await _channel.invokeMethod<Object>('clearFileAttachments');
   }
 
   ///Sets the welcome message mode to live, beta or disabled.
   ///[welcomeMessageMode] An enum to set the welcome message mode to live, beta or disabled.
-  static void setWelcomeMessageMode(
+  static Future<void> setWelcomeMessageMode(
       WelcomeMessageMode welcomeMessageMode) async {
     final List<dynamic> params = <dynamic>[welcomeMessageMode.toString()];
     await _channel.invokeMethod<Object>('setWelcomeMessageMode:', params);
@@ -279,21 +283,21 @@ class Instabug {
 
   ///Reports that the screen has been changed (repro steps)
   ///[screenName] String containing the screen name
-  static void reportScreenChange(String screenName) async {
+  static Future<void> reportScreenChange(String screenName) async {
     final List<dynamic> params = <dynamic>[screenName];
     await _channel.invokeMethod<Object>('reportScreenChange:', params);
   }
 
   ///Sets the repro steps mode
   ///[mode] repro steps mode
-  static void setReproStepsMode(ReproStepsMode reproStepsMode) async {
+  static Future<void> setReproStepsMode(ReproStepsMode reproStepsMode) async {
     final List<dynamic> params = <dynamic>[reproStepsMode.toString()];
     await _channel.invokeMethod<Object>('setReproStepsMode:', params);
   }
 
   ///Android Only
   ///Enables all Instabug functionality
-  static void enableAndroid() async {
+  static Future<void> enableAndroid() async {
     if (Platform.isAndroid) {
       await _channel.invokeMethod<Object>('enable:');
     }
@@ -301,7 +305,7 @@ class Instabug {
 
   ///Android Only
   ///Disables all Instabug functionality
-  static void disableAndroid() async {
+  static Future<void> disableAndroid() async {
     if (Platform.isAndroid) {
       await _channel.invokeMethod<Object>('disable:');
     }

--- a/lib/InstabugLog.dart
+++ b/lib/InstabugLog.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 class InstabugLog {
@@ -13,7 +14,7 @@ class InstabugLog {
   /// These logs are then sent along the next uploaded report.
   /// All log messages are timestamped
   /// Note: logs passed to this method are NOT printed to console
-  static void logError(String message) async {
+  static Future<void> logError(String message) async {
     final List<dynamic> params = <dynamic>[message];
     await _channel.invokeMethod<Object>('logError:', params);
   }
@@ -22,7 +23,7 @@ class InstabugLog {
   /// These logs are then sent along the next uploaded report.
   /// All log messages are timestamped
   /// Note: logs passed to this method are NOT printed to console
-  static void logWarn(String message) async {
+  static Future<void> logWarn(String message) async {
     final List<dynamic> params = <dynamic>[message];
     await _channel.invokeMethod<Object>('logWarn:', params);
   }
@@ -31,7 +32,7 @@ class InstabugLog {
   /// These logs are then sent along the next uploaded report.
   /// All log messages are timestamped
   /// Note: logs passed to this method are NOT printed to console
-  static void logVerbose(String message) async {
+  static Future<void> logVerbose(String message) async {
     final List<dynamic> params = <dynamic>[message];
     await _channel.invokeMethod<Object>('logVerbose:', params);
   }
@@ -40,7 +41,7 @@ class InstabugLog {
   /// These logs are then sent along the next uploaded report.
   /// All log messages are timestamped
   /// Note: logs passed to this method are NOT printed to console
-  static void logDebug(String message) async {
+  static Future<void> logDebug(String message) async {
     final List<dynamic> params = <dynamic>[message];
     await _channel.invokeMethod<Object>('logDebug:', params);
   }
@@ -49,13 +50,13 @@ class InstabugLog {
   /// These logs are then sent along the next uploaded report.
   /// All log messages are timestamped
   /// Note: logs passed to this method are NOT printed to console
-  static void logInfo(String message) async {
+  static Future<void> logInfo(String message) async {
     final List<dynamic> params = <dynamic>[message];
     await _channel.invokeMethod<Object>('logInfo:', params);
   }
 
   /// Clears Instabug internal log
-  static void clearAllLogs() async {
+  static Future<void> clearAllLogs() async {
     await _channel.invokeMethod<Object>('clearAllLogs');
   }
 }

--- a/lib/Replies.dart
+++ b/lib/Replies.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+
 import 'package:flutter/services.dart';
 
-
 class Replies {
-
   static Function _hasChatsCallback;
   static Function _onNewReplyReceivedCallback;
   static Function _unreadRepliesCountCallback;
@@ -16,73 +15,73 @@ class Replies {
   }
 
   static Future<dynamic> _handleMethod(MethodCall call) async {
-  switch(call.method) {
-    case 'hasChatsCallback':
-      _hasChatsCallback(call.arguments);
-      return ;
-    case 'onNewReplyReceivedCallback':
-      _onNewReplyReceivedCallback();
-      return ;
-     case 'unreadRepliesCountCallback':
-      _unreadRepliesCountCallback(call.arguments);
-      return ;
+    switch (call.method) {
+      case 'hasChatsCallback':
+        _hasChatsCallback(call.arguments);
+        return;
+      case 'onNewReplyReceivedCallback':
+        _onNewReplyReceivedCallback();
+        return;
+      case 'unreadRepliesCountCallback':
+        _unreadRepliesCountCallback(call.arguments);
+        return;
+    }
   }
-}
 
   /// Enables and disables everything related to receiving replies.
   /// [boolean] isEnabled
-  static void setEnabled(bool isEnabled) async {
+  static Future<void> setEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
-    await _channel.invokeMethod<Object>('setRepliesEnabled:', params); 
-  } 
+    await _channel.invokeMethod<Object>('setRepliesEnabled:', params);
+  }
 
   ///Manual invocation for replies.
-  static void show() async {
-    await _channel.invokeMethod<Object>('showReplies'); 
-  } 
+  static Future<void> show() async {
+    await _channel.invokeMethod<Object>('showReplies');
+  }
 
-   /// Tells whether the user has chats already or not.
-   ///  [function] - callback that is invoked if chats exist
-  static void hasChats(Function function) async {
-     _channel.setMethodCallHandler(_handleMethod);
+  /// Tells whether the user has chats already or not.
+  ///  [function] - callback that is invoked if chats exist
+  static Future<void> hasChats(Function function) async {
+    _channel.setMethodCallHandler(_handleMethod);
     _hasChatsCallback = function;
-    await _channel.invokeMethod<Object>('hasChats'); 
-  } 
+    await _channel.invokeMethod<Object>('hasChats');
+  }
 
-   ///  Sets a block of code that gets executed when a new message is received.
-   ///  [function] -  A callback that gets executed when a new message is received.
-  static void setOnNewReplyReceivedCallback(Function function) async {
-     _channel.setMethodCallHandler(_handleMethod);
+  ///  Sets a block of code that gets executed when a new message is received.
+  ///  [function] -  A callback that gets executed when a new message is received.
+  static Future<void> setOnNewReplyReceivedCallback(Function function) async {
+    _channel.setMethodCallHandler(_handleMethod);
     _onNewReplyReceivedCallback = function;
-    await _channel.invokeMethod<Object>('setOnNewReplyReceivedCallback'); 
-  } 
+    await _channel.invokeMethod<Object>('setOnNewReplyReceivedCallback');
+  }
 
-   /// Returns the number of unread messages the user currently has.
-   /// Use this method to get the number of unread messages the user
-   /// has, then possibly notify them about it with your own UI.
-   /// [function] callback with argument
-   /// Notifications count, or -1 in case the SDK has not been initialized.
-  static void getUnreadRepliesCount(Function function) async {
+  /// Returns the number of unread messages the user currently has.
+  /// Use this method to get the number of unread messages the user
+  /// has, then possibly notify them about it with your own UI.
+  /// [function] callback with argument
+  /// Notifications count, or -1 in case the SDK has not been initialized.
+  static Future<void> getUnreadRepliesCount(Function function) async {
     _channel.setMethodCallHandler(_handleMethod);
     _unreadRepliesCountCallback = function;
-    await _channel.invokeMethod<Object>('getUnreadRepliesCount'); 
-  } 
+    await _channel.invokeMethod<Object>('getUnreadRepliesCount');
+  }
 
   /// Enables/disables showing in-app notifications when the user receives a new message.
   /// [isEnabled] A boolean to set whether notifications are enabled or disabled.
-  static void setInAppNotificationsEnabled(bool isEnabled) async {
+  static Future<void> setInAppNotificationsEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
-    await _channel.invokeMethod<Object>('setChatNotificationEnabled:', params); 
-  } 
+    await _channel.invokeMethod<Object>('setChatNotificationEnabled:', params);
+  }
 
   /// Set whether new in app notification received will play a small sound notification or not (Default is {@code false})
   /// [isEnabled] A boolean to set whether notifications sound should be played.
   /// @android ONLY
-  static void setInAppNotificationSound(bool isEnabled) async {
+  static Future<void> setInAppNotificationSound(bool isEnabled) async {
     if (Platform.isAndroid) {
       final List<dynamic> params = <dynamic>[isEnabled];
-      await _channel.invokeMethod<Object>('setEnableInAppNotificationSound:', params); 
+      await _channel.invokeMethod<Object>(
+          'setEnableInAppNotificationSound:', params);
     }
-  } 
-
+  }
 }

--- a/lib/Surveys.dart
+++ b/lib/Surveys.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
+
 import 'package:flutter/services.dart';
 
 class Surveys {
@@ -43,7 +44,7 @@ class Surveys {
   /// To manually display any available surveys, call `Instabug.showSurveyIfAvailable()`.
   /// Defaults to `true`.
   /// [isEnabled] A boolean to set whether Instabug Surveys is enabled or disabled.
-  static void setEnabled(bool isEnabled) async {
+  static Future<void> setEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>('setSurveysEnabled:', params);
   }
@@ -51,7 +52,7 @@ class Surveys {
   ///Sets whether auto surveys showing are enabled or not.
   /// [isEnabled] A boolean to indicate whether the
   /// surveys auto showing are enabled or not.
-  static void setAutoShowingEnabled(bool isEnabled) async {
+  static Future<void> setAutoShowingEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>(
         'setAutoShowingSurveysEnabled:', params);
@@ -60,7 +61,7 @@ class Surveys {
   /// Returns an array containing the available surveys.
   /// [function] availableSurveysCallback callback with
   /// argument available surveys
-  static void getAvailableSurveys(Function function) async {
+  static Future<void> getAvailableSurveys(Function function) async {
     _channel.setMethodCallHandler(_handleMethod);
     _availableSurveysCallback = function;
     await _channel.invokeMethod<Object>('getAvailableSurveys');
@@ -70,7 +71,7 @@ class Surveys {
   /// This block is executed on the UI thread. Could be used for performing any
   /// UI changes before the survey's UI is shown.
   /// [function]  A callback that gets executed before presenting the survey's UI.
-  static void setOnShowCallback(Function function) async {
+  static Future<void> setOnShowCallback(Function function) async {
     _channel.setMethodCallHandler(_handleMethod);
     _onShowCallback = function;
     await _channel.invokeMethod<Object>('setOnShowSurveyCallback');
@@ -80,7 +81,7 @@ class Surveys {
   /// This block is executed on the UI thread. Could be used for performing any
   /// UI changes  after the survey's UI is dismissed.
   /// [function]  A callback that gets executed after the survey's UI is dismissed.
-  static void setOnDismissCallback(Function function) async {
+  static Future<void> setOnDismissCallback(Function function) async {
     _channel.setMethodCallHandler(_handleMethod);
     _onDismissCallback = function;
     await _channel.invokeMethod<Object>('setOnDismissSurveyCallback');
@@ -88,7 +89,8 @@ class Surveys {
 
   /// Setting an option for all the surveys to show a welcome screen before
   /// [shouldShowWelcomeScreen] A boolean for setting whether the  welcome screen should show.
-  static void setShouldShowWelcomeScreen(bool shouldShowWelcomeScreen) async {
+  static Future<void> setShouldShowWelcomeScreen(
+      bool shouldShowWelcomeScreen) async {
     final List<dynamic> params = <dynamic>[shouldShowWelcomeScreen];
     await _channel.invokeMethod<Object>(
         'setShouldShowSurveysWelcomeScreen:', params);
@@ -98,7 +100,7 @@ class Surveys {
   /// that match the current device/user.
   /// Does nothing if there are no available surveys or if a survey has already been shown
   /// in the current session.
-  static void showSurveyIfAvailable() async {
+  static Future<void> showSurveyIfAvailable() async {
     await _channel.invokeMethod<Object>('showSurveysIfAvailable');
   }
 
@@ -106,7 +108,7 @@ class Surveys {
   /// Does nothing if there are no available surveys with that specific token.
   /// Answered and cancelled surveys won't show up again.
   /// [surveyToken] - A String with a survey token.
-  static void showSurvey(String surveyToken) async {
+  static Future<void> showSurvey(String surveyToken) async {
     final List<dynamic> params = <dynamic>[surveyToken];
     await _channel.invokeMethod<Object>('showSurveyWithToken:', params);
   }
@@ -115,7 +117,7 @@ class Surveys {
   /// This block is executed on the UI thread. Could be used for performing any
   /// UI changes  after the survey's UI is dismissed.
   /// [function]  A callback that gets executed after the survey's UI is dismissed.
-  static void hasRespondedToSurvey(
+  static Future<void> hasRespondedToSurvey(
       String surveyToken, Function function) async {
     _channel.setMethodCallHandler(_handleMethod);
     _hasRespondedToSurveyCallback = function;
@@ -128,7 +130,7 @@ class Surveys {
   /// @summary Sets url for the published iOS app on AppStore, You can redirect
   /// NPS Surveys or AppRating Surveys to AppStore to let users rate your app on AppStore itself.
   /// [appStoreURL] A String url for the published iOS app on AppStore
-  static void setAppStoreURL(String appStoreURL) async {
+  static Future<void> setAppStoreURL(String appStoreURL) async {
     if (Platform.isIOS) {
       final List<dynamic> params = <dynamic>[appStoreURL];
       await _channel.invokeMethod<Object>('setAppStoreURL:', params);

--- a/lib/utils/http_client_logger.dart
+++ b/lib/utils/http_client_logger.dart
@@ -3,9 +3,7 @@ import 'dart:io';
 import 'package:instabug_flutter/NetworkLogger.dart';
 import 'package:instabug_flutter/models/network_data.dart';
 
-
 class HttpClientLogger {
-
   Map<int, NetworkData> requests = <int, NetworkData>{};
 
   NetworkData _getRequestData(int requestHashCode) {
@@ -15,7 +13,7 @@ class HttpClientLogger {
     return null;
   }
 
-  void onRequest(HttpClientRequest request, { dynamic requestBody }) {
+  void onRequest(HttpClientRequest request, {dynamic requestBody}) {
     final NetworkData requestData = NetworkData();
     requestData.startTime = DateTime.now();
     requestData.method = request.method;
@@ -29,16 +27,18 @@ class HttpClientLogger {
     requests[request.hashCode] = requestData;
   }
 
-  void onResponse(HttpClientResponse response, HttpClientRequest request, {dynamic responseBody}) {
+  void onResponse(HttpClientResponse response, HttpClientRequest request,
+      {dynamic responseBody}) {
     final DateTime endTime = DateTime.now();
     final NetworkData networkData = _getRequestData(request.hashCode);
 
     if (networkData == null) {
-      return null;
+      return;
     }
 
     networkData.status = response.statusCode;
-    networkData.duration = endTime.difference(networkData.startTime).inMilliseconds;
+    networkData.duration =
+        endTime.difference(networkData.startTime).inMilliseconds;
     if (response.headers.contentType != null) {
       networkData.contentType = response.headers.contentType.value;
     }
@@ -52,7 +52,5 @@ class HttpClientLogger {
     }
 
     NetworkLogger.networkLog(networkData);
-
   }
-
 }


### PR DESCRIPTION
## Summary of Changes
Calling a method should never leave the `result` hanging, which is being fixed here for iOS.
This also allows for calling `await` on methods that return `void`.

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [ ] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [ ] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [x] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
