### PR TITLE
[MOB-8360] Add Expirements APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Fixes iOS platform calls not completing with `void` return type
+* Adds Experiments APIs.
 
 ## v10.11.0 (2022-01-04)
 

--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -304,6 +304,31 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
     }
 
     /**
+     * Adds experiments to the next report.
+     *
+     * @param experiments An array of experiments to add.
+     */
+    public void addExperiments(ArrayList<String> experiments) {
+        Instabug.addExperiments(experiments);
+    }
+
+    /**
+     * Removes certain experiments from the next report.
+     *
+     * @param experiments An array of experiments to remove.
+     */
+    public void removeExperiments(ArrayList<String> experiments) {
+        Instabug.removeExperiments(experiments);
+    }
+
+    /**
+     * Clears all experiments from the next report.
+     */
+    public void clearAllExperiments() {
+        Instabug.clearAllExperiments();
+    }
+
+    /**
      * Set custom user attributes that are going to be sent with each feedback, bug
      * or crash.
      *

--- a/example/android/app/src/main/kotlin/com/example/InstabugSample/OnMethodCallTests.java
+++ b/example/android/app/src/main/kotlin/com/example/InstabugSample/OnMethodCallTests.java
@@ -77,6 +77,37 @@ class OnMethodCallTests {
         verify(instabugMock).appendTags(tags);
     }
 
+    public void testAddExperiments() {
+        String methodName = "addExperiments";
+        ArrayList<Object> argsList = new ArrayList<>();
+        ArrayList<String> experiments = new ArrayList<>();
+        experiments.add("exp1");
+        experiments.add("exp2");
+        argsList.add(experiments);
+        Mockito.doNothing().when(instabugMock).addExperiments(any(ArrayList.class));
+        testMethodCall(methodName, argsList);
+        verify(instabugMock).addExperiments(experiments);
+    }
+
+    public void testRemoveExperiments() {
+        String methodName = "removeExperiments";
+        ArrayList<Object> argsList = new ArrayList<>();
+        ArrayList<String> experiments = new ArrayList<>();
+        experiments.add("exp1");
+        experiments.add("exp2");
+        argsList.add(experiments);
+        Mockito.doNothing().when(instabugMock).removeExperiments(any(ArrayList.class));
+        testMethodCall(methodName, argsList);
+        verify(instabugMock).removeExperiments(experiments);
+    }
+
+    public void testClearAllExperiments() {
+        String methodName = "clearAllExperiments";
+        Mockito.doNothing().when(instabugMock).clearAllExperiments();
+        testMethodCall(methodName, null);
+        verify(instabugMock).clearAllExperiments();
+    }
+
     public void testShowBugReportingWithReportTypeAndOptions() {
         String methodName = "showBugReportingWithReportTypeAndOptions";
         ArrayList<Object> argsList = new ArrayList<>();

--- a/example/android/app/src/test/java/com/example/InstabugSample/InstabugFlutterPluginTest.java
+++ b/example/android/app/src/test/java/com/example/InstabugSample/InstabugFlutterPluginTest.java
@@ -42,6 +42,30 @@ public class InstabugFlutterPluginTest {
     }
 
     /**
+     * (ArrayList<String>)
+     */
+    @Test
+    public void testAddExperiments() {
+        new OnMethodCallTests().testAddExperiments();
+    }
+
+    /**
+     * (ArrayList<String>)
+     */
+    @Test
+    public void testRemoveExperiments() {
+        new OnMethodCallTests().testRemoveExperiments();
+    }
+
+    /**
+     * ()
+     */
+    @Test
+    public void testClearAllExperiments() {
+        new OnMethodCallTests().testClearAllExperiments();
+    }
+
+    /**
      * (String, ArrayList<String>)
      */
     @Test

--- a/example/ios/InstabugSampleTests/InstabugSampleTests.m
+++ b/example/ios/InstabugSampleTests/InstabugSampleTests.m
@@ -89,6 +89,61 @@ static const NSTimeInterval kTimeout = 30.0;
      [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
+- (void)testAddExperiments {
+    id mock = OCMClassMock([InstabugFlutterPlugin class]);
+    InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
+    
+    NSArray *experiments = [NSArray arrayWithObjects:@"exp1", @"exp2", nil];
+    NSArray *arguments = [NSArray arrayWithObjects: experiments, nil];
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"addExperiments:" arguments:arguments];
+    [[[mock stub] classMethod] addExperiments:experiments];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+    [instabug  handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
+    [[[mock verify] classMethod] addExperiments:experiments];
+    [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
+- (void)testRemoveExperiments {
+    id mock = OCMClassMock([InstabugFlutterPlugin class]);
+    InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
+    
+    NSArray *experiments = [NSArray arrayWithObjects:@"exp1", @"exp2", nil];
+    NSArray *arguments = [NSArray arrayWithObjects: experiments, nil];
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"removeExperiments:" arguments:arguments];
+    [[[mock stub] classMethod] removeExperiments:experiments];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+    [instabug  handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
+    [[[mock verify] classMethod] removeExperiments:experiments];
+    [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
+- (void)testClearAllExperiments {
+    id mock = OCMClassMock([InstabugFlutterPlugin class]);
+    InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
+    
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"clearAllExperiments" arguments:NULL];
+    [[[mock stub] classMethod] clearAllExperiments];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+    [instabug  handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
+    [[[mock verify] classMethod] clearAllExperiments];
+    [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
  - (void)testShowBugReportingWithReportTypeAndOptions {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];

--- a/ios/Classes/InstabugFlutterPlugin.h
+++ b/ios/Classes/InstabugFlutterPlugin.h
@@ -120,6 +120,23 @@
 + (NSArray *)getTags;
 
 /**
+ * Adds experiments to the next report.
+ * @param experiments An array of experiments to add.
+ */
++ (void)addExperiments:(NSArray *)experiments;
+
+/**
+ * Removes certain experiments from the next report.
+ * @param experiments An array of experiments to remove.
+ */
++ (void)removeExperiments:(NSArray *)experiments;
+
+/**
+ * Clears all experiments from the next report.
+ */
++ (void)clearAllExperiments;
+
+/**
  * Set custom user attributes that are going to be sent with each feedback, bug or crash.
  * @param value User attribute value.
  * @param key User attribute key.

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -236,6 +236,29 @@ NSMutableDictionary *traces;
 }
 
 /**
+ * Adds experiments to the next report.
+ * @param experiments An array of experiments to add.
+ */
++ (void)addExperiments:(NSArray *)experiments {
+    [Instabug addExperiments:experiments];
+}
+
+/**
+ * Removes certain experiments from the next report.
+ * @param experiments An array of experiments to remove.
+ */
++ (void)removeExperiments:(NSArray *)experiments {
+    [Instabug removeExperiments:experiments];
+}
+
+/**
+ * Clears all experiments from the next report.
+ */
++ (void)clearAllExperiments {
+    [Instabug clearAllExperiments];
+}
+
+/**
  * Set custom user attributes that are going to be sent with each feedback, bug or crash.
  * @param value User attribute value.
  * @param key User attribute key.

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -178,6 +178,23 @@ class Instabug {
     return tags?.cast<String>();
   }
 
+  /// Adds experiments to the next report.
+  static Future<void> addExperiments(List<String> experiments) async {
+    final params = <dynamic>[experiments];
+    await _channel.invokeMethod<Object>('addExperiments:', params);
+  }
+
+  /// Removes certain experiments from the next report.
+  static Future<void> removeExperiments(List<String> experiments) async {
+    final params = <dynamic>[experiments];
+    await _channel.invokeMethod<Object>('removeExperiments:', params);
+  }
+
+  /// Clears all experiments from the next report.
+  static Future<void> clearAllExperiments() async {
+    await _channel.invokeMethod<Object>('clearAllExperiments');
+  }
+
   /// Add custom user attribute [value] with a [key] that is going to be sent with each feedback, bug or crash.
   static Future<void> setUserAttribute(String value, String key) async {
     final List<dynamic> params = <dynamic>[value, key];

--- a/test/instabug_flutter_test.dart
+++ b/test/instabug_flutter_test.dart
@@ -281,6 +281,49 @@ void main() {
   });
 
   test(
+    'test addExperiments should be called with argument List of strings',
+    () async {
+      const experiments = ['exp1', 'exp2'];
+      Instabug.addExperiments(experiments);
+      final args = <dynamic>[experiments];
+      expect(log, <Matcher>[
+        isMethodCall(
+          'addExperiments:',
+          arguments: args,
+        )
+      ]);
+    },
+  );
+
+  test(
+    'test removeExperiments should be called with argument List of strings',
+    () async {
+      const experiments = ['exp1', 'exp2'];
+      Instabug.removeExperiments(experiments);
+      final args = <dynamic>[experiments];
+      expect(log, <Matcher>[
+        isMethodCall(
+          'removeExperiments:',
+          arguments: args,
+        )
+      ]);
+    },
+  );
+
+  test(
+    'test clearAllExperiments should be called with no arguments',
+    () async {
+      Instabug.clearAllExperiments();
+      expect(log, <Matcher>[
+        isMethodCall(
+          'clearAllExperiments',
+          arguments: null,
+        )
+      ]);
+    },
+  );
+
+  test(
       'test setUserAttributeWithKey should be called with two string arguments',
       () async {
     const String value = '19';


### PR DESCRIPTION
## Summary of Changes

Add Experiments APIs: `addExperiments`, `removeExperiments`, `clearAllExperiments`.

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [X] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [X] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [X] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
