### PR TITLE
[MOB-8369] Fix `void` calls on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v10.11.1 (2022-02-18)
+
+* Fixes iOS platform calls not completing with `void` return type
+
 ## v10.11.0 (2022-01-04)
 
 * Adds support for APM.endAppLaunch API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v10.11.1 (2022-02-18)
+## master
 
 * Fixes iOS platform calls not completing with `void` return type
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -155,7 +155,7 @@ linter:
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    # - unawaited_futures # too many false positives
+    - unawaited_futures
     # - unnecessary_await_in_return # not yet tested
     - unnecessary_brace_in_string_interps
     - unnecessary_const

--- a/example/ios/InstabugSampleTests/InstabugSampleTests.m
+++ b/example/ios/InstabugSampleTests/InstabugSampleTests.m
@@ -15,127 +15,189 @@
 
 @implementation InstabugSampleTests
 
+static const NSTimeInterval kTimeout = 30.0;
+
  - (void)testShowWelcomeMessageWithMode {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *arguments = [NSArray arrayWithObjects:@"WelcomeMessageMode.live", nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"showWelcomeMessageWithMode:" arguments:arguments];
      [[[mock stub] classMethod] showWelcomeMessageWithMode:@"WelcomeMessageMode.live"];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] showWelcomeMessageWithMode:@"WelcomeMessageMode.live"];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testIdentifyUserWithEmail {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *arguments = [NSArray arrayWithObjects:@"test@test.com", @"name", nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"identifyUserWithEmail:name:" arguments:arguments];
      [[[mock stub] classMethod] identifyUserWithEmail:@"test@test.com"name:@"name"];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] identifyUserWithEmail:@"test@test.com"name:@"name"];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testLogOut {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"logOut" arguments:NULL];
      [[[mock stub] classMethod] logOut];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] logOut];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testAppendTags {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *tags = [NSArray arrayWithObjects:@"tag1", @"tag2", nil];
      NSArray *arguments = [NSArray arrayWithObjects: tags, nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"appendTags:" arguments:arguments];
      [[[mock stub] classMethod] appendTags:tags];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] appendTags:tags];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testShowBugReportingWithReportTypeAndOptions {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *options = [NSArray arrayWithObjects:@"commentFieldRequired", @"disablePostSendingDialog", nil];
      NSArray *arguments = [NSArray arrayWithObjects:@"bug", options, nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"showBugReportingWithReportTypeAndOptions:options:" arguments:arguments];
      [[[mock stub] classMethod] showBugReportingWithReportTypeAndOptions:@"bug"options:options];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] showBugReportingWithReportTypeAndOptions:@"bug"options:options];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testSetSessionProfilerEnabled {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *arguments = [NSArray arrayWithObjects:@(1), nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"setSessionProfilerEnabled:" arguments:arguments];
      [[[mock stub] classMethod] setSessionProfilerEnabled:@(1)];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] setSessionProfilerEnabled:@(1)];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testSetPrimaryColor {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *arguments = [NSArray arrayWithObjects:@(1123123123121), nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"setPrimaryColor:" arguments:arguments];
      [[[mock stub] classMethod] setPrimaryColor:@(1123123123121)];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] setPrimaryColor:@(1123123123121)];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testAddFileAttachmentWithData {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      FlutterStandardTypedData *data;
      NSArray *arguments = [NSArray arrayWithObjects:data, nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"addFileAttachmentWithData:" arguments:arguments];
      [[[mock stub] classMethod] addFileAttachmentWithData:data];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] addFileAttachmentWithData:data];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testSetEnabledAttachmentTypes {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *arguments = [NSArray arrayWithObjects:@(1),@(1),@(1),@(1), nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"setEnabledAttachmentTypes:extraScreenShot:galleryImage:screenRecording:" arguments:arguments];
      [[[mock stub] classMethod] setEnabledAttachmentTypes:@(1) extraScreenShot:@(1) galleryImage:@(1) screenRecording:@(1) ];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] setEnabledAttachmentTypes:@(1) extraScreenShot:@(1) galleryImage:@(1) screenRecording:@(1)];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
  - (void)testSetEmailFieldRequiredForFeatureRequests {
      id mock = OCMClassMock([InstabugFlutterPlugin class]);
      InstabugFlutterPlugin *instabug = [[InstabugFlutterPlugin alloc] init];
-     id result;
 
      NSArray *actions = [NSArray arrayWithObjects:@"reportBug", @"requestNewFeature", nil];
      NSArray *arguments = [NSArray arrayWithObjects:@(1), actions, nil];
      FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"setEmailFieldRequiredForFeatureRequests:forAction:" arguments:arguments];
      [[[mock stub] classMethod] setEmailFieldRequiredForFeatureRequests:@(1) forAction:actions];
-     [instabug  handleMethodCall:call result:result];
+
+     XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+     [instabug handleMethodCall:call result:^(id _Nullable result) {
+         XCTAssertNil(result);
+         [expectation fulfill];
+     }];
+
      [[[mock verify] classMethod] setEmailFieldRequiredForFeatureRequests:@(1) forAction:actions];
+     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
  }
 
 

--- a/ios/Classes/InstabugFlutterPlugin.h
+++ b/ios/Classes/InstabugFlutterPlugin.h
@@ -428,7 +428,7 @@
   *
   * @param isEnabled whether chat notification is reburied or not
   */
-- (void)setChatNotificationEnabled:(NSNumber *)isEnabled;
++ (void)setChatNotificationEnabled:(NSNumber *)isEnabled;
 
 + (void)networkLog:(NSDictionary *)networkData;
 

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -41,15 +41,13 @@ NSMutableDictionary *traces;
         NSMethodSignature *signature = [inv methodSignature];
         const char *type = [signature methodReturnType];
 
-        if (result != nil) {
-            if (strcmp(type, "v") != 0) {
-                void *returnVal;
-                [inv getReturnValue:&returnVal];
-                NSObject *resultSet = (__bridge NSObject *)returnVal;
-                result(resultSet);
-            } else {
-                result(nil);
-            }
+        if (strcmp(type, "v") != 0) {
+            void *returnVal;
+            [inv getReturnValue:&returnVal];
+            NSObject *resultSet = (__bridge NSObject *)returnVal;
+            result(resultSet);
+        } else {
+            result(nil);
         }
     }
     if (!isImplemented) {

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -20,36 +20,40 @@ NSMutableDictionary *traces;
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     BOOL isImplemented = NO;
-      SEL method = NSSelectorFromString(call.method);
-      if([[InstabugFlutterPlugin class] respondsToSelector:method]) {
+    SEL method = NSSelectorFromString(call.method);
+    if ([[InstabugFlutterPlugin class] respondsToSelector:method]) {
         isImplemented = YES;
         NSInvocation *inv = [NSInvocation invocationWithMethodSignature:[[InstabugFlutterPlugin class] methodSignatureForSelector:method]];
         [inv setSelector:method];
         [inv setTarget:[InstabugFlutterPlugin class]];
         /*
          * Indices 0 and 1 indicate the hidden arguments self and _cmd,
-         * respectively; you should set these values directly with the target and selector properties. 
+         * respectively; you should set these values directly with the target and selector properties.
          * Use indices 2 and greater for the arguments normally passed in a message.
          */
         NSInteger index = 2;
         NSArray* argumentsArray = call.arguments;
         for (NSObject * argument in argumentsArray) {
-          [inv setArgument:&(argument) atIndex:index];
-          index++;
-        }      
+            [inv setArgument:&argument atIndex:index];
+            index++;
+        }
         [inv invoke];
-          NSMethodSignature *signature = [inv methodSignature];
-          const char *type = [signature methodReturnType];
+        NSMethodSignature *signature = [inv methodSignature];
+        const char *type = [signature methodReturnType];
 
-          if (strcmp(type, "v") != 0) {
-            void *returnVal;
-            [inv getReturnValue:&returnVal];
-            NSObject *resultSet = (__bridge NSObject *)returnVal;
-            result(resultSet);
-          }
-      }
+        if (result != nil) {
+            if (strcmp(type, "v") != 0) {
+                void *returnVal;
+                [inv getReturnValue:&returnVal];
+                NSObject *resultSet = (__bridge NSObject *)returnVal;
+                result(resultSet);
+            } else {
+                result(nil);
+            }
+        }
+    }
     if (!isImplemented) {
-      result(FlutterMethodNotImplemented);
+        result(FlutterMethodNotImplemented);
     }
 }
 

--- a/lib/APM.dart
+++ b/lib/APM.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:instabug_flutter/models/network_data.dart';
 import 'package:instabug_flutter/models/trace.dart';
@@ -32,21 +33,21 @@ class APM {
 
   /// Enables or disables APM feature.
   /// [boolean] isEnabled
-  static void setEnabled(bool isEnabled) async {
+  static Future<void> setEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>('setAPMEnabled:', params);
   }
 
   /// Sets log Level to determine level of details in a log
   /// [logLevel] Enum value to determine the level
-  static void setLogLevel(LogLevel logLevel) async {
+  static Future<void> setLogLevel(LogLevel logLevel) async {
     final List<dynamic> params = <dynamic>[logLevel.toString()];
     await _channel.invokeMethod<Object>('setAPMLogLevel:', params);
   }
 
   /// Enables or disables cold app launch tracking.
   /// [boolean] isEnabled
-  static void setColdAppLaunchEnabled(bool isEnabled) async {
+  static Future<void> setColdAppLaunchEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>('setColdAppLaunchEnabled:', params);
   }
@@ -69,7 +70,7 @@ class APM {
       }
     };
     _startExecutionTraceCallback = callback;
-    _channel.invokeMethod<Object>('startExecutionTrace:id:', params);
+    await _channel.invokeMethod<Object>('startExecutionTrace:id:', params);
     return completer.future;
   }
 
@@ -77,7 +78,7 @@ class APM {
   /// [String] id of the trace.
   /// [String] key of attribute.
   /// [String] value of attribute.
-  static void setExecutionTraceAttribute(
+  static Future<void> setExecutionTraceAttribute(
       String id, String key, String value) async {
     final List<dynamic> params = <dynamic>[
       id.toString(),
@@ -90,27 +91,27 @@ class APM {
 
   /// Ends an execution trace.
   /// [String] id of the trace.
-  static void endExecutionTrace(String id) async {
+  static Future<void> endExecutionTrace(String id) async {
     final List<dynamic> params = <dynamic>[id];
     await _channel.invokeMethod<Object>('endExecutionTrace:', params);
   }
 
   /// Enables or disables auto UI tracing.
   /// [boolean] isEnabled
-  static void setAutoUITraceEnabled(bool isEnabled) async {
+  static Future<void> setAutoUITraceEnabled(bool isEnabled) async {
     final List<dynamic> params = <dynamic>[isEnabled];
     await _channel.invokeMethod<Object>('setAutoUITraceEnabled:', params);
   }
 
   /// Starts UI trace.
   /// [String] name
-  static void startUITrace(String name) async {
+  static Future<void> startUITrace(String name) async {
     final List<dynamic> params = <dynamic>[name];
     await _channel.invokeMethod<Object>('startUITrace:', params);
   }
 
   /// Ends UI trace.
-  static void endUITrace() async {
+  static Future<void> endUITrace() async {
     await _channel.invokeMethod<Object>('endUITrace');
   }
   /// Ends UI trace.

--- a/lib/CrashReporting.dart
+++ b/lib/CrashReporting.dart
@@ -26,7 +26,7 @@ class CrashReporting {
 
   static Future<void> reportCrash(dynamic exception, StackTrace stack) async {
     if (kReleaseMode && enabled) {
-      _reportUnhandledCrash(exception, stack);
+      await _reportUnhandledCrash(exception, stack);
     } else {
       FlutterError.dumpErrorToConsole(
           FlutterErrorDetails(stack: stack, exception: exception));
@@ -38,12 +38,12 @@ class CrashReporting {
   /// [StackTrace] stack
   static Future<void> reportHandledCrash(dynamic exception,
       [StackTrace? stack]) async {
-    _sendCrash(exception, stack ?? StackTrace.current, true);
+    await _sendCrash(exception, stack ?? StackTrace.current, true);
   }
 
   static Future<void> _reportUnhandledCrash(
       dynamic exception, StackTrace stack) async {
-    _sendCrash(exception, stack, false);
+    await _sendCrash(exception, stack, false);
   }
 
   static Future<void> _sendCrash(

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -148,7 +148,7 @@ class Instabug {
 
   /// Sets the verbosity level of logs used to debug The SDK. The defualt value in debug
   /// mode is sdkDebugLogsLevelVerbose and in production is sdkDebugLogsLevelError.
-  static void setSdkDebugLogsLevel(
+  static Future<void> setSdkDebugLogsLevel(
       IBGSDKDebugLogsLevel sdkDebugLogsLevel) async {
     final List<dynamic> params = <dynamic>[sdkDebugLogsLevel.toString()];
     await _channel.invokeMethod<Object>('setSdkDebugLogsLevel:', params);
@@ -238,7 +238,7 @@ class Instabug {
   /// Android only
   /// Enable/disable SDK logs
   /// [debugEnabled] desired state of debug mode.
-  static void setDebugEnabled(bool debugEnabled) async {
+  static Future<void> setDebugEnabled(bool debugEnabled) async {
     if (PlatformManager.instance.isAndroid()) {
       final List<dynamic> params = <dynamic>[debugEnabled];
       await _channel.invokeMethod<Object>('setDebugEnabled:', params);

--- a/test/instabug_flutter_test.dart
+++ b/test/instabug_flutter_test.dart
@@ -106,7 +106,7 @@ void main() {
   test('startWithToken:invocationEvents: should be called on iOS', () async {
     when(mockPlatform.isIOS()).thenAnswer((_) => true);
 
-    Instabug.start(appToken, invocationEvents);
+    await Instabug.start(appToken, invocationEvents);
     final List<dynamic> args = <dynamic>[
       appToken,
       <String>[InvocationEvent.floatingButton.toString()]
@@ -120,7 +120,7 @@ void main() {
   });
 
   test('showWelcomeMessageWithMode: Test', () async {
-    Instabug.showWelcomeMessageWithMode(WelcomeMessageMode.beta);
+    await Instabug.showWelcomeMessageWithMode(WelcomeMessageMode.beta);
     final List<dynamic> args = <dynamic>[WelcomeMessageMode.beta.toString()];
     expect(log, <Matcher>[
       isMethodCall(
@@ -131,7 +131,7 @@ void main() {
   });
 
   test('identifyUserWithEmail:name: Test', () async {
-    Instabug.identifyUser(email, name);
+    await Instabug.identifyUser(email, name);
     final List<dynamic> args = <dynamic>[email, name];
     expect(log, <Matcher>[
       isMethodCall(
@@ -142,7 +142,7 @@ void main() {
   });
 
   test('identifyUserWithEmail:name: Test Optional Parameter', () async {
-    Instabug.identifyUser(email);
+    await Instabug.identifyUser(email);
     final List<dynamic> args = <dynamic>[email, null];
     expect(log, <Matcher>[
       isMethodCall(
@@ -153,12 +153,12 @@ void main() {
   });
 
   test('logOut Test', () async {
-    Instabug.logOut();
+    await Instabug.logOut();
     expect(log, <Matcher>[isMethodCall('logOut', arguments: null)]);
   });
 
   test('setLocale:', () async {
-    Instabug.setLocale(IBGLocale.german);
+    await Instabug.setLocale(IBGLocale.german);
     final List<dynamic> args = <dynamic>[IBGLocale.german.toString()];
     expect(log, <Matcher>[
       isMethodCall(
@@ -169,7 +169,7 @@ void main() {
   });
 
   test('setSdkDebugLogsLevel:', () async {
-    Instabug.setSdkDebugLogsLevel(IBGSDKDebugLogsLevel.verbose);
+    await Instabug.setSdkDebugLogsLevel(IBGSDKDebugLogsLevel.verbose);
     final List<dynamic> args = <dynamic>[
       IBGSDKDebugLogsLevel.verbose.toString()
     ];
@@ -182,7 +182,7 @@ void main() {
   });
 
   test('logVerbose: Test', () async {
-    InstabugLog.logVerbose(message);
+    await InstabugLog.logVerbose(message);
     final List<dynamic> args = <dynamic>[message];
     expect(log, <Matcher>[
       isMethodCall(
@@ -193,7 +193,7 @@ void main() {
   });
 
   test('logDebug: Test', () async {
-    InstabugLog.logDebug(message);
+    await InstabugLog.logDebug(message);
     final List<dynamic> args = <dynamic>[message];
     expect(log, <Matcher>[
       isMethodCall(
@@ -204,7 +204,7 @@ void main() {
   });
 
   test('logInfo: Test', () async {
-    InstabugLog.logInfo(message);
+    await InstabugLog.logInfo(message);
     final List<dynamic> args = <dynamic>[message];
     expect(log, <Matcher>[
       isMethodCall(
@@ -215,12 +215,12 @@ void main() {
   });
 
   test('clearAllLogs: Test', () async {
-    InstabugLog.clearAllLogs();
+    await InstabugLog.clearAllLogs();
     expect(log, <Matcher>[isMethodCall('clearAllLogs', arguments: null)]);
   });
 
   test('logError: Test', () async {
-    InstabugLog.logError(message);
+    await InstabugLog.logError(message);
     final List<dynamic> args = <dynamic>[message];
     expect(log, <Matcher>[
       isMethodCall(
@@ -231,7 +231,7 @@ void main() {
   });
 
   test('logWarn: Test', () async {
-    InstabugLog.logWarn(message);
+    await InstabugLog.logWarn(message);
     final List<dynamic> args = <dynamic>[message];
     expect(log, <Matcher>[
       isMethodCall(
@@ -244,7 +244,7 @@ void main() {
   test('test setColorTheme should be called with argument colorTheme',
       () async {
     const ColorTheme colorTheme = ColorTheme.dark;
-    Instabug.setColorTheme(colorTheme);
+    await Instabug.setColorTheme(colorTheme);
     final List<dynamic> args = <dynamic>[colorTheme.toString()];
     expect(log, <Matcher>[
       isMethodCall(
@@ -257,7 +257,7 @@ void main() {
   test('test appendTags should be called with argument List of strings',
       () async {
     const List<String> tags = ['tag1', 'tag2'];
-    Instabug.appendTags(tags);
+    await Instabug.appendTags(tags);
     final List<dynamic> args = <dynamic>[tags];
     expect(log, <Matcher>[
       isMethodCall(
@@ -268,7 +268,7 @@ void main() {
   });
 
   test('test resetTags should be called with no arguments', () async {
-    Instabug.resetTags();
+    await Instabug.resetTags();
     expect(log, <Matcher>[isMethodCall('resetTags', arguments: null)]);
   });
 
@@ -285,7 +285,7 @@ void main() {
       () async {
     const String value = '19';
     const String key = 'Age';
-    Instabug.setUserAttribute(value, key);
+    await Instabug.setUserAttribute(value, key);
     final List<dynamic> args = <dynamic>[value, key];
     expect(log, <Matcher>[
       isMethodCall(
@@ -298,7 +298,7 @@ void main() {
   test('test removeUserAttributeForKey should be called with a string argument',
       () async {
     const String key = 'Age';
-    Instabug.removeUserAttribute(key);
+    await Instabug.removeUserAttribute(key);
     final List<dynamic> args = <dynamic>[key];
     expect(log, <Matcher>[
       isMethodCall(
@@ -328,7 +328,7 @@ void main() {
   });
 
   test('show Test', () async {
-    Instabug.show();
+    await Instabug.show();
     expect(log, <Matcher>[
       isMethodCall(
         'show',
@@ -338,7 +338,7 @@ void main() {
   });
 
   test('logUserEventWithName: Test', () async {
-    Instabug.logUserEvent(name);
+    await Instabug.logUserEvent(name);
     final List<dynamic> args = <dynamic>[name];
     expect(log, <Matcher>[
       isMethodCall(
@@ -352,7 +352,7 @@ void main() {
       () async {
     const String value = 'Some key';
     const CustomTextPlaceHolderKey key = CustomTextPlaceHolderKey.shakeHint;
-    Instabug.setValueForStringWithKey(value, key);
+    await Instabug.setValueForStringWithKey(value, key);
     final List<dynamic> args = <dynamic>[value, key.toString()];
     expect(log, <Matcher>[
       isMethodCall(
@@ -365,7 +365,7 @@ void main() {
   test('setSessionProfilerEnabled: Test', () async {
     const bool sessionProfilerEnabled = true;
     final List<dynamic> args = <dynamic>[sessionProfilerEnabled];
-    Instabug.setSessionProfilerEnabled(sessionProfilerEnabled);
+    await Instabug.setSessionProfilerEnabled(sessionProfilerEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setSessionProfilerEnabled:',
@@ -379,7 +379,7 @@ void main() {
 
     const bool debugEnabled = true;
     final List<dynamic> args = <dynamic>[debugEnabled];
-    Instabug.setDebugEnabled(debugEnabled);
+    await Instabug.setDebugEnabled(debugEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setDebugEnabled:',
@@ -391,7 +391,7 @@ void main() {
   test('setPrimaryColor: Test', () async {
     const c = Color.fromRGBO(255, 0, 255, 1.0);
     final List<dynamic> args = <dynamic>[c.value];
-    Instabug.setPrimaryColor(c);
+    await Instabug.setPrimaryColor(c);
     expect(log, <Matcher>[
       isMethodCall(
         'setPrimaryColor:',
@@ -403,7 +403,7 @@ void main() {
   test('setUserData: Test', () async {
     const s = 'This is a String';
     final List<dynamic> args = <dynamic>[s];
-    Instabug.setUserData(s);
+    await Instabug.setUserData(s);
     expect(log, <Matcher>[
       isMethodCall(
         'setUserData:',
@@ -416,7 +416,7 @@ void main() {
     const filePath = 'filePath';
     const fileName = 'fileName';
     final List<dynamic> args = <dynamic>[filePath, fileName];
-    Instabug.addFileAttachmentWithURL(filePath, fileName);
+    await Instabug.addFileAttachmentWithURL(filePath, fileName);
     expect(log, <Matcher>[
       isMethodCall(
         'addFileAttachmentWithURL:',
@@ -429,7 +429,7 @@ void main() {
     final bdata = Uint8List(10);
     const fileName = 'fileName';
     final List<dynamic> args = <dynamic>[bdata, fileName];
-    Instabug.addFileAttachmentWithData(bdata, fileName);
+    await Instabug.addFileAttachmentWithData(bdata, fileName);
     expect(log, <Matcher>[
       isMethodCall(
         'addFileAttachmentWithData:',
@@ -439,7 +439,7 @@ void main() {
   });
 
   test('clearFileAttachments Test', () async {
-    Instabug.clearFileAttachments();
+    await Instabug.clearFileAttachments();
     expect(log, <Matcher>[
       isMethodCall(
         'clearFileAttachments',
@@ -450,7 +450,7 @@ void main() {
 
   test('setWelcomeMessageMode Test', () async {
     final List<dynamic> args = <dynamic>[WelcomeMessageMode.live.toString()];
-    Instabug.setWelcomeMessageMode(WelcomeMessageMode.live);
+    await Instabug.setWelcomeMessageMode(WelcomeMessageMode.live);
     expect(log, <Matcher>[
       isMethodCall(
         'setWelcomeMessageMode:',
@@ -462,7 +462,7 @@ void main() {
   test('reportScreenChange Test', () async {
     const String screenName = 'screen 1';
     final List<dynamic> args = <dynamic>[screenName];
-    Instabug.reportScreenChange(screenName);
+    await Instabug.reportScreenChange(screenName);
     expect(log, <Matcher>[
       isMethodCall(
         'reportScreenChange:',
@@ -473,7 +473,7 @@ void main() {
 
   test('setReproStepsMode Test', () async {
     final List<dynamic> args = <dynamic>[ReproStepsMode.enabled.toString()];
-    Instabug.setReproStepsMode(ReproStepsMode.enabled);
+    await Instabug.setReproStepsMode(ReproStepsMode.enabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setReproStepsMode:',
@@ -485,7 +485,7 @@ void main() {
   test('setBugReportingEnabled: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    BugReporting.setEnabled(isEnabled);
+    await BugReporting.setEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setBugReportingEnabled:',
@@ -500,7 +500,7 @@ void main() {
 
     when(mockPlatform.isIOS()).thenAnswer((_) => true);
 
-    BugReporting.setShakingThresholdForiPhone(iPhoneShakingThreshold);
+    await BugReporting.setShakingThresholdForiPhone(iPhoneShakingThreshold);
     expect(log, <Matcher>[
       isMethodCall(
         'setShakingThresholdForiPhone:',
@@ -515,7 +515,7 @@ void main() {
 
     when(mockPlatform.isIOS()).thenAnswer((_) => true);
 
-    BugReporting.setShakingThresholdForiPad(iPadShakingThreshold);
+    await BugReporting.setShakingThresholdForiPad(iPadShakingThreshold);
     expect(log, <Matcher>[
       isMethodCall(
         'setShakingThresholdForiPad:',
@@ -530,7 +530,7 @@ void main() {
 
     when(mockPlatform.isAndroid()).thenAnswer((_) => true);
 
-    BugReporting.setShakingThresholdForAndroid(androidThreshold);
+    await BugReporting.setShakingThresholdForAndroid(androidThreshold);
     expect(log, <Matcher>[
       isMethodCall(
         'setShakingThresholdForAndroid:',
@@ -540,7 +540,7 @@ void main() {
   });
 
   test('setOnInvokeCallback Test', () async {
-    BugReporting.setOnInvokeCallback(() => () {});
+    await BugReporting.setOnInvokeCallback(() => () {});
     expect(log, <Matcher>[
       isMethodCall(
         'setOnInvokeCallback',
@@ -550,7 +550,7 @@ void main() {
   });
 
   test('setOnDismissCallback Test', () async {
-    BugReporting.setOnDismissCallback(() => () {});
+    await BugReporting.setOnDismissCallback(() => () {});
     expect(log, <Matcher>[
       isMethodCall(
         'setOnDismissCallback',
@@ -560,7 +560,7 @@ void main() {
   });
 
   test('setInvocationEvents Test', () async {
-    BugReporting.setInvocationEvents(
+    await BugReporting.setInvocationEvents(
         <InvocationEvent>[InvocationEvent.floatingButton]);
     final List<dynamic> args = <dynamic>[
       <String>[InvocationEvent.floatingButton.toString()]
@@ -574,7 +574,7 @@ void main() {
   });
 
   test('setInvocationEvents Test', () async {
-    BugReporting.setInvocationEvents(null);
+    await BugReporting.setInvocationEvents(null);
     final List<dynamic> args = <dynamic>[<String>[]];
     expect(log, <Matcher>[
       isMethodCall(
@@ -587,7 +587,7 @@ void main() {
   test(
       'setEnabledAttachmentTypes:extraScreenShot:galleryImage:screenRecording: Test',
       () async {
-    BugReporting.setEnabledAttachmentTypes(false, false, false, false);
+    await BugReporting.setEnabledAttachmentTypes(false, false, false, false);
     final List<dynamic> args = <dynamic>[false, false, false, false];
     expect(log, <Matcher>[
       isMethodCall(
@@ -598,7 +598,7 @@ void main() {
   });
 
   test('setInvocationEvents Test', () async {
-    BugReporting.setReportTypes(<ReportType>[ReportType.feedback]);
+    await BugReporting.setReportTypes(<ReportType>[ReportType.feedback]);
     final List<dynamic> args = <dynamic>[
       <String>[ReportType.feedback.toString()]
     ];
@@ -611,7 +611,7 @@ void main() {
   });
 
   test('setInvocationEvents Test', () async {
-    BugReporting.setExtendedBugReportMode(
+    await BugReporting.setExtendedBugReportMode(
         ExtendedBugReportMode.enabledWithOptionalFields);
     final List<dynamic> args = <dynamic>[
       ExtendedBugReportMode.enabledWithOptionalFields.toString()
@@ -625,7 +625,7 @@ void main() {
   });
 
   test('setInvocationOptions Test', () async {
-    BugReporting.setInvocationOptions(
+    await BugReporting.setInvocationOptions(
         <InvocationOption>[InvocationOption.emailFieldHidden]);
     final List<dynamic> args = <dynamic>[
       <String>[InvocationOption.emailFieldHidden.toString()]
@@ -639,7 +639,7 @@ void main() {
   });
 
   test('setInvocationOptions Test: empty', () async {
-    BugReporting.setInvocationOptions(null);
+    await BugReporting.setInvocationOptions(null);
     final List<dynamic> args = <dynamic>[<String>[]];
     expect(log, <Matcher>[
       isMethodCall(
@@ -650,7 +650,7 @@ void main() {
   });
 
   test('showBugReportingWithReportTypeAndOptions:options Test', () async {
-    BugReporting.show(
+    await BugReporting.show(
         ReportType.bug, <InvocationOption>[InvocationOption.emailFieldHidden]);
     final List<dynamic> args = <dynamic>[
       ReportType.bug.toString(),
@@ -666,7 +666,7 @@ void main() {
 
   test('showBugReportingWithReportTypeAndOptions:options Test: empty options',
       () async {
-    BugReporting.show(ReportType.bug, null);
+    await BugReporting.show(ReportType.bug, null);
     final List<dynamic> args = <dynamic>[ReportType.bug.toString(), <String>[]];
     expect(log, <Matcher>[
       isMethodCall(
@@ -679,7 +679,7 @@ void main() {
   test('setSurveysEnabled: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    Surveys.setEnabled(isEnabled);
+    await Surveys.setEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setSurveysEnabled:',
@@ -691,7 +691,7 @@ void main() {
   test('setAutoShowingSurveysEnabled: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    Surveys.setAutoShowingEnabled(isEnabled);
+    await Surveys.setAutoShowingEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setAutoShowingSurveysEnabled:',
@@ -701,7 +701,7 @@ void main() {
   });
 
   test('setOnShowSurveyCallback Test', () async {
-    Surveys.setOnShowCallback(() => () {});
+    await Surveys.setOnShowCallback(() => () {});
     expect(log, <Matcher>[
       isMethodCall(
         'setOnShowSurveyCallback',
@@ -711,7 +711,7 @@ void main() {
   });
 
   test('setOnDismissSurveyCallback Test', () async {
-    Surveys.setOnDismissCallback(() => () {});
+    await Surveys.setOnDismissCallback(() => () {});
     expect(log, <Matcher>[
       isMethodCall(
         'setOnDismissSurveyCallback',
@@ -723,7 +723,7 @@ void main() {
   test('setShouldShowSurveysWelcomeScreen: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    Surveys.setShouldShowWelcomeScreen(isEnabled);
+    await Surveys.setShouldShowWelcomeScreen(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setShouldShowSurveysWelcomeScreen:',
@@ -733,7 +733,7 @@ void main() {
   });
 
   test('showSurveysIfAvailable Test', () async {
-    Surveys.showSurveyIfAvailable();
+    await Surveys.showSurveyIfAvailable();
     expect(log, <Matcher>[
       isMethodCall(
         'showSurveysIfAvailable',
@@ -745,7 +745,7 @@ void main() {
   test('showSurveyWithToken Test', () async {
     const token = 'token';
     final List<dynamic> args = <dynamic>[token];
-    Surveys.showSurvey(token);
+    await Surveys.showSurvey(token);
     expect(log, <Matcher>[
       isMethodCall(
         'showSurveyWithToken:',
@@ -757,7 +757,7 @@ void main() {
   test('hasRespondedToSurvey Test', () async {
     const token = 'token';
     final List<dynamic> args = <dynamic>[token];
-    Surveys.hasRespondedToSurvey(token, () => () {});
+    await Surveys.hasRespondedToSurvey(token, () => () {});
     expect(log, <Matcher>[
       isMethodCall(
         'hasRespondedToSurveyWithToken:',
@@ -772,7 +772,7 @@ void main() {
 
     when(mockPlatform.isIOS()).thenAnswer((_) => true);
 
-    Surveys.setAppStoreURL(appStoreURL);
+    await Surveys.setAppStoreURL(appStoreURL);
     expect(log, <Matcher>[
       isMethodCall(
         'setAppStoreURL:',
@@ -782,7 +782,7 @@ void main() {
   });
 
   test('showFeatureRequests Test', () async {
-    FeatureRequests.show();
+    await FeatureRequests.show();
     expect(
         log, <Matcher>[isMethodCall('showFeatureRequests', arguments: null)]);
   });
@@ -793,7 +793,7 @@ void main() {
       isEmailFieldRequired,
       <String>[ActionType.addCommentToFeature.toString()]
     ];
-    FeatureRequests.setEmailFieldRequired(
+    await FeatureRequests.setEmailFieldRequired(
         isEmailFieldRequired, [ActionType.addCommentToFeature]);
     expect(log, <Matcher>[
       isMethodCall(
@@ -804,14 +804,14 @@ void main() {
   });
 
   test('showChats Test', () async {
-    Chats.show();
+    await Chats.show();
     expect(log, <Matcher>[isMethodCall('showChats', arguments: null)]);
   });
 
   test('setChatsEnabled: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    Chats.setEnabled(isEnabled);
+    await Chats.setEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setChatsEnabled:',
@@ -823,7 +823,7 @@ void main() {
   test('setRepliesEnabled: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    Replies.setEnabled(isEnabled);
+    await Replies.setEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setRepliesEnabled:',
@@ -838,7 +838,7 @@ void main() {
 
     when(mockPlatform.isAndroid()).thenAnswer((_) => true);
 
-    Replies.setInAppNotificationSound(isEnabled);
+    await Replies.setInAppNotificationSound(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setEnableInAppNotificationSound:',
@@ -848,24 +848,24 @@ void main() {
   });
 
   test('showReplies Test', () async {
-    Replies.show();
+    await Replies.show();
     expect(log, <Matcher>[isMethodCall('showReplies', arguments: null)]);
   });
 
   test('hasChats Test', () async {
-    Replies.hasChats(() => () {});
+    await Replies.hasChats(() => () {});
     expect(log, <Matcher>[isMethodCall('hasChats', arguments: null)]);
   });
 
   test('setOnNewReplyReceivedCallback Test', () async {
-    Replies.setOnNewReplyReceivedCallback(() => () {});
+    await Replies.setOnNewReplyReceivedCallback(() => () {});
     expect(log, <Matcher>[
       isMethodCall('setOnNewReplyReceivedCallback', arguments: null)
     ]);
   });
 
   test('getUnreadRepliesCount Test', () async {
-    Replies.getUnreadRepliesCount(() => () {});
+    await Replies.getUnreadRepliesCount(() => () {});
     expect(
         log, <Matcher>[isMethodCall('getUnreadRepliesCount', arguments: null)]);
   });
@@ -873,7 +873,7 @@ void main() {
   test('setChatNotificationEnabled: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    Replies.setInAppNotificationsEnabled(isEnabled);
+    await Replies.setInAppNotificationsEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setChatNotificationEnabled:',
@@ -887,7 +887,7 @@ void main() {
         NetworkData(method: 'method', url: 'url', startTime: DateTime.now());
     final List<dynamic> args = <dynamic>[data.toMap()];
     final networkLogger = NetworkLogger();
-    networkLogger.networkLog(data);
+    await networkLogger.networkLog(data);
     expect(log, <Matcher>[
       isMethodCall(
         'networkLog:',
@@ -899,7 +899,7 @@ void main() {
   test('setCrashReportingEnabled: Test', () async {
     const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    CrashReporting.setEnabled(isEnabled);
+    await CrashReporting.setEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setCrashReportingEnabled:',
@@ -926,7 +926,7 @@ void main() {
       final crashData = CrashData(
           exception.toString(), Platform.operatingSystem.toString(), frames);
       final List<dynamic> args = <dynamic>[jsonEncode(crashData), handled];
-      CrashReporting.reportHandledCrash(exception, stack);
+      await CrashReporting.reportHandledCrash(exception, stack);
       expect(log, <Matcher>[
         isMethodCall(
           'sendJSCrashByReflection:handled:',
@@ -1004,9 +1004,9 @@ void main() {
   });
 
   test('setAPMEnabled: Test', () async {
-    bool isEnabled = false;
+    const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    APM.setEnabled(isEnabled);
+    await APM.setEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setAPMEnabled:',
@@ -1016,9 +1016,9 @@ void main() {
   });
 
   test('setAPMLogLevel: Test', () async {
-    LogLevel level = LogLevel.error;
+    const level = LogLevel.error;
     final List<dynamic> args = <dynamic>[level.toString()];
-    APM.setLogLevel(level);
+    await APM.setLogLevel(level);
     expect(log, <Matcher>[
       isMethodCall(
         'setAPMLogLevel:',
@@ -1028,9 +1028,9 @@ void main() {
   });
 
   test('setColdAppLaunchEnabled: Test', () async {
-    bool isEnabled = false;
+    const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    APM.setColdAppLaunchEnabled(isEnabled);
+    await APM.setColdAppLaunchEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setColdAppLaunchEnabled:',
@@ -1043,7 +1043,7 @@ void main() {
     const String name = 'test_trace';
     final DateTime timestamp = DateTime.now();
     final List<dynamic> args = <dynamic>[name.toString(), timestamp.toString()];
-    APM.startExecutionTrace(name);
+    await APM.startExecutionTrace(name);
     expect(log, <Matcher>[
       isMethodCall(
         'startExecutionTrace:id:',
@@ -1071,7 +1071,7 @@ void main() {
   test('setCrashReportingEnabled: Test', () async {
     const bool isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    CrashReporting.setEnabled(isEnabled);
+    await CrashReporting.setEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setCrashReportingEnabled:',
@@ -1081,9 +1081,9 @@ void main() {
   });
 
   test('setAutoUITraceEnabled: Test', () async {
-    bool isEnabled = false;
+    const isEnabled = false;
     final List<dynamic> args = <dynamic>[isEnabled];
-    APM.setAutoUITraceEnabled(isEnabled);
+    await APM.setAutoUITraceEnabled(isEnabled);
     expect(log, <Matcher>[
       isMethodCall(
         'setAutoUITraceEnabled:',
@@ -1093,9 +1093,9 @@ void main() {
   });
 
   test('startUITrace: Test', () async {
-    String name = 'UI_Trace';
+    const name = 'UI_Trace';
     final List<dynamic> args = <dynamic>[name];
-    APM.startUITrace(name);
+    await APM.startUITrace(name);
     expect(log, <Matcher>[
       isMethodCall(
         'startUITrace:',
@@ -1105,8 +1105,7 @@ void main() {
   });
 
   test('endUITrace: Test', () async {
-    final List<dynamic> args = <dynamic>[null];
-    APM.endUITrace();
+    await APM.endUITrace();
     expect(log, <Matcher>[isMethodCall('endUITrace', arguments: null)]);
   });
 


### PR DESCRIPTION
## Summary of Changes

* Fix future dart calls for void methods on iOS.  (Thanks to @via-guy)
* Fix & Improve iOS unit tests.