### PR TITLE
Improve CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,14 @@
 version: 2
+
 jobs:
+   danger:
+    docker:
+      - image: circleci/ruby:2.3
+    steps:
+      - checkout
+      - run: bundle install        
+      - run: bundle exec danger
+
    flutter_lint:
     docker:
       - image: cirrusci/flutter
@@ -73,9 +82,6 @@ jobs:
       - image: cirrusci/flutter
     steps:
       - checkout
-      - run: sudo gem install bundler:2.1.4
-      - run: bundle check || sudo bundle install        
-      - run: bundle exec danger
       - run: flutter doctor
       - run: flutter packages get
       - run: flutter pub run build_runner build --delete-conflicting-outputs
@@ -87,9 +93,6 @@ jobs:
       - image: cirrusci/flutter:2.2.3
     steps:
       - checkout
-      - run: sudo gem install bundler:2.1.4
-      - run: bundle check || sudo bundle install        
-      - run: bundle exec danger
       - run: flutter doctor
       - run: flutter packages get
       - run: flutter pub run build_runner build --delete-conflicting-outputs
@@ -149,6 +152,7 @@ workflows:
   version: 2
   build-test-and-approval-deploy:
     jobs:
+      - danger
       - flutter_lint
       - flutter_tests
       - flutter_tests_2.2.3
@@ -157,6 +161,7 @@ workflows:
       - hold_pub_release:
           type: approval
           requires:
+            - danger
             - flutter_lint
             - flutter_tests
             - flutter_tests_2.2.3
@@ -174,6 +179,7 @@ workflows:
       - hold_gh_ibg_release:
           type: approval
           requires:
+            - danger
             - flutter_lint
             - flutter_tests
             - flutter_tests_2.2.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,6 @@ jobs:
     parameters:
       version:
         type: string
-      codecov:
-        type: boolean
     docker:
       - image: cirrusci/flutter:<< parameters.version >>
     steps:
@@ -24,7 +22,6 @@ jobs:
       - run: flutter pub get
       - run: flutter pub run build_runner build --delete-conflicting-outputs
       - run: flutter test --coverage
-      - run: if << parameters.codecov >>; then bash <(curl -s https://codecov.io/bash); fi
 
    android_tests:
     working_directory: ~/project/example/android
@@ -140,21 +137,17 @@ workflows:
     jobs:
       - flutter_lint
       - flutter_test:
-          name: flutter_test_stable
-          version: stable
-          codecov: true
-      - flutter_test:
-          name: flutter_test_2-2-3
-          version: 2.2.3
-          codecov: false
+          matrix:
+            parameters:
+              version: ["stable", "2.2.3"]
       - android_tests
       - ios_tests
       - hold_pub_release:
           type: approval
           requires:
             - flutter_lint
-            - flutter_test_stable
-            - flutter_test_2-2-3
+            - flutter_test-stable
+            - flutter_test-2.2.3
             - android_tests
             - ios_tests
           filters:
@@ -170,8 +163,8 @@ workflows:
           type: approval
           requires:
             - flutter_lint
-            - flutter_test_stable
-            - flutter_test_2-2-3
+            - flutter_test-stable
+            - flutter_test-2.2.3
             - android_tests
             - ios_tests
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,11 @@ jobs:
       - flutter/install_sdk_and_pub:
           flutter_version: 2.2.3
           app-dir: ..
-      - android/start-emulator-and-run-tests:
-          system-image: system-images;android-30;google_apis;x86
-          additional-avd-args: -d "Nexus 5"
-          post-emulator-launch-assemble-command: flutter build apk
-          test-command: ./gradlew app:connectedAndroidTest
+      # - android/start-emulator-and-run-tests:
+      #     system-image: system-images;android-30;google_apis;x86
+      #     additional-avd-args: -d "Nexus 5"
+      #     post-emulator-launch-assemble-command: flutter build apk
+      #     test-command: ./gradlew app:connectedAndroidTest
       - android/run-tests:
           test-command: ./gradlew test
   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,15 @@
 version: 2
 jobs:
+   flutter_lint:
+    docker:
+      - image: cirrusci/flutter
+    steps:
+      - checkout
+      - run: flutter pub get
+      - run: flutter format --set-exit-if-changed .
+      - run: flutter analyze .
+      - run: flutter pub publish --dry-run
+
    android_tests:
     working_directory: ~/project/example/android
     macos:
@@ -71,8 +81,6 @@ jobs:
       - run: flutter pub run build_runner build --delete-conflicting-outputs
       - run: flutter test --coverage
       - run: bash <(curl -s https://codecov.io/bash)
-      - run: dartanalyzer --options analysis_options.yaml --fatal-warnings lib
-      - run: flutter pub publish --dry-run
 
    flutter_tests_2.2.3:
     docker:
@@ -141,6 +149,7 @@ workflows:
   version: 2
   build-test-and-approval-deploy:
     jobs:
+      - flutter_lint
       - flutter_tests
       - flutter_tests_2.2.3
       - android_tests
@@ -148,6 +157,7 @@ workflows:
       - hold_pub_release:
           type: approval
           requires:
+            - flutter_lint
             - flutter_tests
             - flutter_tests_2.2.3
             - android_tests
@@ -164,6 +174,7 @@ workflows:
       - hold_gh_ibg_release:
           type: approval
           requires:
+            - flutter_lint
             - flutter_tests
             - flutter_tests_2.2.3
             - android_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: bundle install        
       - run: bundle exec danger
 
-   flutter_lint:
+   lint_flutter:
     docker:
       - image: cirrusci/flutter
     steps:
@@ -23,7 +23,7 @@ jobs:
       - run: flutter analyze .
       - run: flutter pub publish --dry-run
 
-   flutter_test:
+   test_flutter:
     parameters:
       version:
         type: string
@@ -35,7 +35,7 @@ jobs:
       - run: flutter pub run build_runner build --delete-conflicting-outputs
       - run: flutter test --coverage
 
-   android_test:
+   test_android:
     working_directory: ~/project/example/android
     executor:
       name: android/android-machine
@@ -55,7 +55,7 @@ jobs:
       - android/run-tests:
           test-command: ./gradlew test
   
-   ios_test:
+   test_ios:
     working_directory: ~/project/example/ios
     macos:
       xcode: 12.5.1
@@ -74,7 +74,7 @@ jobs:
                        -destination 'name=iPhone 12 Pro Max' \
                        test | xcpretty
 
-   pub_release:
+   release_pub:
     docker:
       - image: cirrusci/flutter
     steps:
@@ -82,7 +82,7 @@ jobs:
       - run: chmod +x ./release.sh
       - run: ./release.sh
 
-   gh_ibg_release:
+   release_gh_ibg:
     macos:
       xcode: "12.5.1"
     working_directory: "~"
@@ -99,46 +99,46 @@ workflows:
   build-test-and-approval-deploy:
     jobs:
       - danger
-      - flutter_lint
-      - flutter_test:
+      - lint_flutter
+      - test_flutter:
           matrix:
             parameters:
               version: [stable, 2.2.3]
-      - android_test
-      - ios_test
-      - hold_pub_release:
+      - test_android
+      - test_ios
+      - hold_release_pub:
           type: approval
           requires:
             - danger
-            - flutter_lint
-            - flutter_test-stable
-            - flutter_test-2.2.3
-            - android_test
-            - ios_test
+            - lint_flutter
+            - test_flutter-stable
+            - test_flutter-2.2.3
+            - test_android
+            - test_ios
           filters:
             branches:
               only: master
-      - pub_release:
+      - release_pub:
           requires:
-            - hold_pub_release
+            - hold_release_pub
           filters:
             branches:
               only: master
-      - hold_gh_ibg_release:
+      - hold_release_gh_ibg:
           type: approval
           requires:
             - danger
-            - flutter_lint
-            - flutter_test-stable
-            - flutter_test-2.2.3
-            - android_test
-            - ios_test
+            - lint_flutter
+            - test_flutter-stable
+            - test_flutter-2.2.3
+            - test_android
+            - test_ios
           filters:
             branches:
               only: master
-      - gh_ibg_release:
+      - release_gh_ibg:
           requires:
-            - hold_gh_ibg_release
+            - hold_release_gh_ibg
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - run: git clone https://InstabugCI:$RELEASE_GITHUB_TOKEN@github.com/Instabug/Escape.git
+      - run: git clone git@github.com:Instabug/Escape.git
       - run: cd Escape && swift build -c release
       - run: cd Escape/.build/release && cp -f Escape /usr/local/bin/escape
       - run: cd project && Escape flutter publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,35 +47,24 @@ jobs:
       - android/run-tests:
           test-command: ./gradlew test
   
-   ios_tests:
+   ios_test:
+    working_directory: ~/project/example/ios
     macos:
-      xcode: "12.3.0"
-    working_directory: ~/project/example
-    environment:
-      FL_OUTPUT_DIR: output
+      xcode: 12.5.1
     steps:
       - checkout:
           path: ~/project
-      - run:
-          name: Install CocoaPods
-          command: sudo gem install cocoapods
-      - run:
-          name: download flutter SDK
-          command: if ! test -f "~/flutter_sdk.zip"; then curl -o ~/flutter_sdk.zip https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_2.2.3-stable.zip; fi
-      - run:
-          name: unzip flutter SDK
-          command: unzip ~/flutter_sdk.zip -d ~
-      - run:
-          name: export flutter path
-          command: echo 'export PATH="$PATH:~/flutter/bin"'  >> $BASH_ENV
-      - run: flutter doctor
-      - run: flutter pub get
-      - run:
-          name: Install Pods
-          command: cd ios && pod install --repo-update
-      - run:
-          name: Build and run tests
-          command: cd ios && xcodebuild  -allowProvisioningUpdates   -workspace Runner.xcworkspace   -scheme Runner   -sdk iphonesimulator   -destination 'platform=iOS Simulator,name=iPhone 12 Pro Max,OS=14.3'   test | xcpretty
+      - flutter/install_sdk_and_pub:
+          flutter_version: 2.2.3
+          app-dir: ..
+      - run: pod install --repo-update
+      - run: |
+            xcodebuild -allowProvisioningUpdates \
+                       -workspace Runner.xcworkspace \
+                       -scheme Runner \
+                       -sdk iphonesimulator \
+                       -destination 'name=iPhone 12 Pro Max' \
+                       test | xcpretty
 
    pub_release:
     docker:
@@ -107,7 +96,7 @@ workflows:
             parameters:
               version: [stable, 2.2.3]
       - android_test
-      - ios_tests
+      - ios_test
       - hold_pub_release:
           type: approval
           requires:
@@ -115,7 +104,7 @@ workflows:
             - flutter_test-stable
             - flutter_test-2.2.3
             - android_test
-            - ios_tests
+            - ios_test
           filters:
             branches:
               only: master
@@ -132,7 +121,7 @@ workflows:
             - flutter_test-stable
             - flutter_test-2.2.3
             - android_test
-            - ios_tests
+            - ios_test
           filters:
             branches:
               only: master
@@ -142,4 +131,3 @@ workflows:
           filters:
             branches:
               only: master
-              

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,6 @@
 version: 2.1
 
 jobs:
-   danger:
-    docker:
-      - image: circleci/ruby:2.3
-    steps:
-      - checkout
-      - run: bundle install        
-      - run: bundle exec danger
-
    flutter_lint:
     docker:
       - image: cirrusci/flutter
@@ -146,7 +138,6 @@ workflows:
   version: 2
   build-test-and-approval-deploy:
     jobs:
-      - danger
       - flutter_lint
       - flutter_test:
           name: flutter_test_stable
@@ -161,7 +152,6 @@ workflows:
       - hold_pub_release:
           type: approval
           requires:
-            - danger
             - flutter_lint
             - flutter_test_stable
             - flutter_test_2-2-3
@@ -179,7 +169,6 @@ workflows:
       - hold_gh_ibg_release:
           type: approval
           requires:
-            - danger
             - flutter_lint
             - flutter_test_stable
             - flutter_test_2-2-3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
     parameters:
       version:
         type: string
+      codecov:
+        type: boolean
     docker:
       - image: cirrusci/flutter:<< parameters.version >>
     steps:
@@ -34,6 +36,7 @@ jobs:
       - run: flutter pub get
       - run: flutter pub run build_runner build --delete-conflicting-outputs
       - run: flutter test --coverage
+      - run: if << parameters.codecov >>; then bash <(curl -s https://codecov.io/bash); fi
 
    test_android:
     working_directory: ~/project/example/android
@@ -101,9 +104,13 @@ workflows:
       - danger
       - lint_flutter
       - test_flutter:
-          matrix:
-            parameters:
-              version: [stable, 2.2.3]
+          name: test_flutter-stable
+          version: stable
+          codecov: true
+      - test_flutter:
+          name: test_flutter-2.2.3
+          version: 2.2.3
+          codecov: false
       - test_android
       - test_ios
       - hold_release_pub:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+orbs:
+  android: circleci/android@2.0
+  flutter: circleci/flutter@1.0
+
 jobs:
    flutter_lint:
     docker:
@@ -23,64 +27,26 @@ jobs:
       - run: flutter pub run build_runner build --delete-conflicting-outputs
       - run: flutter test --coverage
 
-   android_tests:
+   android_test:
     working_directory: ~/project/example/android
-    macos:
-      xcode: "12.3.0"
-    environment:
-      JVM_OPTS: -Xmx3200m
+    executor:
+      name: android/android-machine
+      resource-class: xlarge
+      tag: 2022.04.1
     steps:
       - checkout:
           path: ~/project
-      - run:
-          name: Install JAVA
-          command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask homebrew/cask-versions/adoptopenjdk8
-      - run:
-          name: Install Android sdk
-          command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask android-sdk
-      - run:
-          name: Setup environment variables
-          command: |
-            echo 'export PATH="$PATH:/usr/local/opt/node@8/bin:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin:/usr/local/share/android-sdk/tools/bin"' >> $BASH_ENV
-            echo 'export JAVA_HOME=`/usr/libexec/java_home -v 1.8`' >> $BASH_ENV
-            echo 'export ANDROID_HOME="/usr/local/share/android-sdk"' >> $BASH_ENV
-            echo 'export ANDROID_SDK_HOME="/usr/local/share/android-sdk"' >> $BASH_ENV
-            echo 'export ANDROID_SDK_ROOT="/usr/local/share/android-sdk"' >> $BASH_ENV
-            echo 'export QEMU_AUDIO_DRV=none' >> $BASH_ENV
-            echo 'export PATH="$PATH:~/flutter/bin"'  >> $BASH_ENV
-      - run:
-          name: Install emulator dependencies
-          command: (yes | sdkmanager "platform-tools" "platforms;android-26" "extras;intel;Hardware_Accelerated_Execution_Manager" "build-tools;26.0.0" "system-images;android-26;google_apis;x86" "emulator" --verbose) || true
-      - run:
-          name: chmod permissions
-          command: chmod +x ./gradlew
-      - run: avdmanager create avd -n Pixel_2_API_26 -k "system-images;android-26;google_apis;x86" -g google_apis -d "Nexus 5"
-      - run:
-          name: Run emulator in background
-          command: /usr/local/share/android-sdk/tools/emulator @Pixel_2_API_26 -noaudio -no-boot-anim -no-window
-          background: true
-      - run:
-          name: download flutter SDK
-          command: if ! test -f "~/flutter_sdk.zip"; then curl -o ~/flutter_sdk.zip https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_2.2.3-stable.zip; fi
-      - run:
-          name: unzip flutter SDK
-          command: unzip ~/flutter_sdk.zip -d ~
-      - run: flutter doctor
-      - run: 
-          name: Flutter build
-          command: cd ..; flutter build apk
-      - run:
-          name: Download Android Dependencies
-          command: ./gradlew androidDependencies
-      - run:
-          name: Run Unit Tests
-          command: ./gradlew test
-      # - run:
-      #     name: Run UI Tests
-      #     command: ./gradlew app:connectedAndroidTest
-
+      - flutter/install_sdk_and_pub:
+          flutter_version: 2.2.3
+          app-dir: ..
+      - android/start-emulator-and-run-tests:
+          system-image: system-images;android-30;google_apis;x86
+          additional-avd-args: -d "Nexus 5"
+          post-emulator-launch-assemble-command: flutter build apk
+          test-command: ./gradlew app:connectedAndroidTest
+      - android/run-tests:
+          test-command: ./gradlew test
+  
    ios_tests:
     macos:
       xcode: "12.3.0"
@@ -139,8 +105,8 @@ workflows:
       - flutter_test:
           matrix:
             parameters:
-              version: ["stable", "2.2.3"]
-      - android_tests
+              version: [stable, 2.2.3]
+      - android_test
       - ios_tests
       - hold_pub_release:
           type: approval
@@ -148,7 +114,7 @@ workflows:
             - flutter_lint
             - flutter_test-stable
             - flutter_test-2.2.3
-            - android_tests
+            - android_test
             - ios_tests
           filters:
             branches:
@@ -165,7 +131,7 @@ workflows:
             - flutter_lint
             - flutter_test-stable
             - flutter_test-2.2.3
-            - android_tests
+            - android_test
             - ios_tests
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
    danger:
@@ -18,6 +18,21 @@ jobs:
       - run: flutter format --set-exit-if-changed .
       - run: flutter analyze .
       - run: flutter pub publish --dry-run
+
+   flutter_test:
+    parameters:
+      version:
+        type: string
+      codecov:
+        type: boolean
+    docker:
+      - image: cirrusci/flutter:<< parameters.version >>
+    steps:
+      - checkout
+      - run: flutter pub get
+      - run: flutter pub run build_runner build --delete-conflicting-outputs
+      - run: flutter test --coverage
+      - run: if << parameters.codecov >>; then bash <(curl -s https://codecov.io/bash); fi
 
    android_tests:
     working_directory: ~/project/example/android
@@ -77,27 +92,6 @@ jobs:
       #     name: Run UI Tests
       #     command: ./gradlew app:connectedAndroidTest
 
-   flutter_tests:
-    docker:
-      - image: cirrusci/flutter
-    steps:
-      - checkout
-      - run: flutter doctor
-      - run: flutter packages get
-      - run: flutter pub run build_runner build --delete-conflicting-outputs
-      - run: flutter test --coverage
-      - run: bash <(curl -s https://codecov.io/bash)
-
-   flutter_tests_2.2.3:
-    docker:
-      - image: cirrusci/flutter:2.2.3
-    steps:
-      - checkout
-      - run: flutter doctor
-      - run: flutter packages get
-      - run: flutter pub run build_runner build --delete-conflicting-outputs
-      - run: flutter test --coverage
-
    ios_tests:
     macos:
       xcode: "12.3.0"
@@ -154,8 +148,14 @@ workflows:
     jobs:
       - danger
       - flutter_lint
-      - flutter_tests
-      - flutter_tests_2.2.3
+      - flutter_test:
+          name: flutter_test_stable
+          version: stable
+          codecov: true
+      - flutter_test:
+          name: flutter_test_2-2-3
+          version: 2.2.3
+          codecov: false
       - android_tests
       - ios_tests
       - hold_pub_release:
@@ -163,8 +163,8 @@ workflows:
           requires:
             - danger
             - flutter_lint
-            - flutter_tests
-            - flutter_tests_2.2.3
+            - flutter_test_stable
+            - flutter_test_2-2-3
             - android_tests
             - ios_tests
           filters:
@@ -181,8 +181,8 @@ workflows:
           requires:
             - danger
             - flutter_lint
-            - flutter_tests
-            - flutter_tests_2.2.3
+            - flutter_test_stable
+            - flutter_test_2-2-3
             - android_tests
             - ios_tests
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,14 @@ orbs:
   flutter: circleci/flutter@1.0
 
 jobs:
+   danger:
+    docker:
+      - image: circleci/ruby:2.7.2
+    steps:
+      - checkout
+      - run: bundle install        
+      - run: bundle exec danger
+
    flutter_lint:
     docker:
       - image: cirrusci/flutter
@@ -90,6 +98,7 @@ workflows:
   version: 2
   build-test-and-approval-deploy:
     jobs:
+      - danger
       - flutter_lint
       - flutter_test:
           matrix:
@@ -100,6 +109,7 @@ workflows:
       - hold_pub_release:
           type: approval
           requires:
+            - danger
             - flutter_lint
             - flutter_test-stable
             - flutter_test-2.2.3
@@ -117,6 +127,7 @@ workflows:
       - hold_gh_ibg_release:
           type: approval
           requires:
+            - danger
             - flutter_lint
             - flutter_test-stable
             - flutter_test-2.2.3


### PR DESCRIPTION
## Summary of Changes

- Rename jobs to the following format `<action>_<platform>`.
- Extract `danger` to a separate job.
- Extract `lint_flutter` to a separate job.
- Check for format in `lint_flutter` job.
- Use Android Orb for `test_android` job.
- Clone Escape via SSH.

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [ ] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [ ] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [ ] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
