### PR TITLE
[MOB-8740] Run CI tests on Flutter 2.10.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
 
    flutter_tests:
     docker:
-      - image: cirrusci/flutter
+      - image: cirrusci/flutter:2.10.5
     steps:
       - checkout
       - run: sudo gem install bundler:1.16.1


### PR DESCRIPTION
## Summary of Changes
- Pin Flutter version to 2.10.5 on CI 
