### PR TITLE
[MOB-8741] Direct call for media projection method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Adds BugReporting.setFloatingButtonEdge API
 * Supports starting SDK from Dart only.
+* Fixes an issue with Android screenshots being black on release mode on SDK v10.13.0
 
 ## v10.13.0 (2022-03-31)
 

--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -9,6 +9,7 @@ import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.instabug.apm.APM;
 import com.instabug.apm.model.ExecutionTrace;
@@ -165,7 +166,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
                 .setInvocationEvents(invocationEventsArray)
                 .build();
 
-        enableScreenShotByMediaProjection();
+        enableScreenShotByMediaProjection(true);
     }
 
     /**
@@ -429,20 +430,9 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
     /**
      * Enables taking screenshots by media projection.
      */
-    private void enableScreenShotByMediaProjection() {
-        try {
-            Method method = getMethod(Class.forName("com.instabug.bug.BugReporting"),
-                    "setScreenshotByMediaProjectionEnabled", boolean.class);
-            if (method != null) {
-                method.invoke(null, true);
-            }
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        }
+    @VisibleForTesting
+    public static void enableScreenShotByMediaProjection(boolean isScreenshotByMediaProjectionEnabled) {
+        BugReporting.setScreenshotByMediaProjectionEnabled(isScreenshotByMediaProjectionEnabled);
     }
 
     /**

--- a/example/android/app/src/androidTest/java/com/example/InstabugSample/InvokeInstabugUITest.java
+++ b/example/android/app/src/androidTest/java/com/example/InstabugSample/InvokeInstabugUITest.java
@@ -16,6 +16,8 @@ import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.matcher.ViewMatchers.withResourceName;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+import com.instabug.instabugflutter.InstabugFlutterPlugin;
+
 @RunWith(AndroidJUnit4.class)
 public class InvokeInstabugUITest {
 
@@ -37,18 +39,7 @@ public class InvokeInstabugUITest {
     }
 
     private void disableScreenShotByMediaProjection() {
-        try {
-            Method method = getMethod(Class.forName("com.instabug.bug.BugReporting"), "setScreenshotByMediaProjectionEnabled", boolean.class);
-            if (method != null) {
-                method.invoke(null, false);
-            }
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        }
+        InstabugFlutterPlugin.enableScreenShotByMediaProjection(false);
     }
 
     public static Method getMethod(Class clazz, String methodName, Class... parameterType) {


### PR DESCRIPTION
## Summary of Changes
- Call media projection method directly instead of by reflection. (#232)
