### PR TITLE
[MOB-8893] Bump Native SDKs to v11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
 }
 dependencies {
-    implementation 'com.instabug.library:instabug:10.13.0'
+    implementation 'com.instabug.library:instabug:11.2.0'
     testImplementation 'junit:junit:4.12'
 }
 

--- a/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/instabugflutter/ArgsRegistry.java
@@ -175,8 +175,6 @@ final class ArgsRegistry {
         args.put("CustomTextPlaceHolderKey.conversationsListTitle", InstabugCustomTextPlaceHolder.Key.CONVERSATIONS_LIST_TITLE);
         args.put("CustomTextPlaceHolderKey.audioRecordingPermissionDenied", InstabugCustomTextPlaceHolder.Key.AUDIO_RECORDING_PERMISSION_DENIED);
         args.put("CustomTextPlaceHolderKey.conversationTextFieldHint", InstabugCustomTextPlaceHolder.Key.CONVERSATION_TEXT_FIELD_HINT);
-        args.put("CustomTextPlaceHolderKey.bugReportHeader", InstabugCustomTextPlaceHolder.Key.BUG_REPORT_HEADER);
-        args.put("CustomTextPlaceHolderKey.feedbackReportHeader", InstabugCustomTextPlaceHolder.Key.FEEDBACK_REPORT_HEADER);
         args.put("CustomTextPlaceHolderKey.voiceMessagePressAndHoldToRecord", InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
         args.put("CustomTextPlaceHolderKey.voiceMessageReleaseToAttach", InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         args.put("CustomTextPlaceHolderKey.reportSuccessfullySent", InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);

--- a/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/instabugflutter/ArgsRegistryTest.java
@@ -267,8 +267,6 @@ public class ArgsRegistryTest {
         keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATIONS_LIST_TITLE);
         keys.add(InstabugCustomTextPlaceHolder.Key.AUDIO_RECORDING_PERMISSION_DENIED);
         keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATION_TEXT_FIELD_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BUG_REPORT_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.FEEDBACK_REPORT_HEADER);
         keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
         keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);
@@ -307,8 +305,6 @@ public class ArgsRegistryTest {
         keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATIONS_LIST_TITLE);
         keys.add(InstabugCustomTextPlaceHolder.Key.AUDIO_RECORDING_PERMISSION_DENIED);
         keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATION_TEXT_FIELD_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BUG_REPORT_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.FEEDBACK_REPORT_HEADER);
         keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
         keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
         keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -649,9 +649,10 @@ NSMutableDictionary *traces;
   * @return the desired value of whether the user has responded to the survey or not.
   */
 + (void)hasRespondedToSurveyWithToken:(NSString *)surveyToken {
-    bool hasResponded = [IBGSurveys hasRespondedToSurveyWithToken:surveyToken];
-    NSNumber *boolNumber = [NSNumber numberWithBool:hasResponded];
-    [channel invokeMethod:@"hasRespondedToSurveyCallback" arguments:boolNumber];
+    [IBGSurveys hasRespondedToSurveyWithToken:surveyToken completionHandler:^(BOOL hasResponded){
+      NSNumber *boolNumber = [NSNumber numberWithBool:hasResponded];
+      [channel invokeMethod:@"hasRespondedToSurveyCallback" arguments:boolNumber];
+    }];
 }
 
 /**
@@ -1052,8 +1053,6 @@ NSMutableDictionary *traces;
       @"CustomTextPlaceHolderKey.conversationsListTitle": kIBGChatsTitleStringName,
       @"CustomTextPlaceHolderKey.audioRecordingPermissionDenied": kIBGAudioRecordingPermissionDeniedTitleStringName,
       @"CustomTextPlaceHolderKey.conversationTextFieldHint": kIBGChatReplyFieldPlaceholderStringName,
-      @"CustomTextPlaceHolderKey.bugReportHeader": kIBGReportBugStringName,
-      @"CustomTextPlaceHolderKey.feedbackReportHeader": kIBGReportFeedbackStringName,
       @"CustomTextPlaceHolderKey.voiceMessagePressAndHoldToRecord": kIBGRecordingMessageToHoldTextStringName,
       @"CustomTextPlaceHolderKey.voiceMessageReleaseToAttach": kIBGRecordingMessageToReleaseTextStringName,
       @"CustomTextPlaceHolderKey.reportSuccessfullySent": kIBGThankYouAlertMessageStringName,

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '10.13.0'
+  s.dependency 'Instabug', '11.0.2'
 
   s.ios.deployment_target = '10.0'
   s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -67,8 +67,6 @@ enum CustomTextPlaceHolderKey {
   conversationsListTitle,
   audioRecordingPermissionDenied,
   conversationTextFieldHint,
-  bugReportHeader,
-  feedbackReportHeader,
   voiceMessagePressAndHoldToRecord,
   voiceMessageReleaseToAttach,
   reportSuccessfullySent,


### PR DESCRIPTION
## Summary of Changes

- Bump iOS SDK to v11.0.2
- Bump Android SDK to v11.2.0
- Remove the string keys `bugReportHeader` and `feedbackReportHeader`. Use `reportBug` and `reportFeedback` as an alternative
- Update `Surveys.hasRespondedToSurvey` implementation on iOS
