### PR TITLE
[MOB-9109] Bump deprecated Xcode versions for affected CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,17 @@ jobs:
       - run: cd Escape && swift build -c release
       - run: cd Escape/.build/release && cp -f Escape /usr/local/bin/escape
       - run: cd project && Escape flutter publish
+
+   gh_ibg_release_replica:
+    macos:
+      xcode: "13.4.1"
+    working_directory: "~"
+    steps:
+      - checkout:
+          path: ~/project
+      - run: git clone https://InstabugCI:$RELEASE_GITHUB_TOKEN@github.com/Instabug/Escape.git
+      - run: cd Escape && swift build -c release
+      - run: cd Escape/.build/release && cp -f Escape /usr/local/bin/escape
       
 workflows:
   version: 2
@@ -145,6 +156,7 @@ workflows:
       - flutter_tests_2.2.3
       - android_tests
       - ios_tests
+      - gh_ibg_release_replica
       - hold_pub_release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
 
    gh_ibg_release:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.4.1"
     working_directory: "~"
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,17 +136,6 @@ jobs:
       - run: cd Escape && swift build -c release
       - run: cd Escape/.build/release && cp -f Escape /usr/local/bin/escape
       - run: cd project && Escape flutter publish
-
-   gh_ibg_release_replica:
-    macos:
-      xcode: "13.4.1"
-    working_directory: "~"
-    steps:
-      - checkout:
-          path: ~/project
-      - run: git clone https://InstabugCI:$RELEASE_GITHUB_TOKEN@github.com/Instabug/Escape.git
-      - run: cd Escape && swift build -c release
-      - run: cd Escape/.build/release && cp -f Escape /usr/local/bin/escape
       
 workflows:
   version: 2
@@ -156,7 +145,6 @@ workflows:
       - flutter_tests_2.2.3
       - android_tests
       - ios_tests
-      - gh_ibg_release_replica
       - hold_pub_release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
 
    ios_tests:
     macos:
-      xcode: "12.3.0"
+      xcode: "13.4.1"
     working_directory: ~/project/example
     environment:
       FL_OUTPUT_DIR: output
@@ -115,7 +115,7 @@ jobs:
           command: cd ios && pod install --repo-update
       - run:
           name: Build and run tests
-          command: cd ios && xcodebuild  -allowProvisioningUpdates   -workspace Runner.xcworkspace   -scheme Runner   -sdk iphonesimulator   -destination 'platform=iOS Simulator,name=iPhone 12 Pro Max,OS=14.3'   test | xcpretty
+          command: cd ios && xcodebuild  -allowProvisioningUpdates   -workspace Runner.xcworkspace   -scheme Runner   -sdk iphonesimulator   -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max,OS=15.5'   test | xcpretty
 
    pub_release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
    android_tests:
     working_directory: ~/project/example/android
     macos:
-      xcode: "12.3.0"
+      xcode: "13.4.1"
     environment:
       JVM_OPTS: -Xmx3200m
     steps:


### PR DESCRIPTION
## Description of the change
- Bumps xcode version to v13.4.1 for `ios_tests` job
- Bumps xcode version to v13.4.1 for `android_tests` job
- Bumps xcode version to v13.4.1 for `gh_ibg_release` job
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
