### PR TITLE
[MOB-9669] Allow brew Auto Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,10 @@ jobs:
           path: ~/project
       - run:
           name: Install JAVA
-          command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask homebrew/cask-versions/adoptopenjdk8
+          command: brew install --cask homebrew/cask-versions/adoptopenjdk8
       - run:
           name: Install Android sdk
-          command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask android-sdk
+          command: brew install --cask android-sdk
       - run:
           name: Setup environment variables
           command: |


### PR DESCRIPTION
## Description of the change
- Remove `HOMEBREW_NO_AUTO_UPDATE` flag to fix failing `android_tests` job
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
