### PR TITLE
[MOB-9934] Fix `BugReporting.setInvocationEvents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Fixes BugReporting.setInvocationEvents always setting them to none.
+* Fixes an issue with BugReporting.setInvocationEvents on iOS that always sets the event to none.
 
 ## v11.0.0 (2022-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fixes BugReporting.setInvocationEvents always setting them to none.
+
 ## v11.0.0 (2022-07-20)
 
 * Bumps Instabug native SDKs to v11

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -491,7 +491,7 @@ NSMutableDictionary *traces;
   */
 + (void)setInvocationEvents:(NSArray *)invocationEventsArray {
     NSDictionary *constants = [self constants];
-    NSInteger invocationEvents = IBGInvocationEventNone;
+    NSInteger invocationEvents = 0;
     for (NSString * invocationEvent in invocationEventsArray) {
         invocationEvents |= ((NSNumber *) constants[invocationEvent]).integerValue;
     }


### PR DESCRIPTION
## Description of the change

`BugReporting.setInvocationEvents` used to always set the invocation events to **none** due to wrong initialization value.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
