### PR TITLE
[MOB-10037] Add missing iOS permission in example app

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -42,8 +42,8 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Instabug needs access to microphone for bug reporting</string>
+	<string>Instabug needs access to your microphone so you can attach voice notes.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Instabug needs access to photo library for bug reporting</string>
+	<string>Instabug needs access to your photo library so you can attach images.</string>
 </dict>
 </plist>

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Instabug needs access to microphone for bug reporting</string>
 </dict>
 </plist>

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Instabug needs access to microphone for bug reporting</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Instabug needs access to photo library for bug reporting</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

On iOS, the example app crashes if you try to use video recording in bug reporting attachments as the app doesn't specify the microphone usage description (used when the app asks for permission) in the `Info.plist` file.

Same for attaching photos from the gallery, the feature wouldn't work because of the missing permission.

## Solution

I added the microphone (`NSMicrophoneUsageDescription`) and photo library (`NSPhotoLibraryUsageDescription`) usage description to the example app's iOS `Info.plist`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
