### PR TITLE
[MOB-10300] Remove unused code in Android UI tests

### DIFF
--- a/example/android/app/src/androidTest/java/com/example/InstabugSample/InvokeInstabugUITest.java
+++ b/example/android/app/src/androidTest/java/com/example/InstabugSample/InvokeInstabugUITest.java
@@ -7,9 +7,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
@@ -40,26 +37,6 @@ public class InvokeInstabugUITest {
 
     private void disableScreenShotByMediaProjection() {
         InstabugFlutterPlugin.enableScreenShotByMediaProjection(false);
-    }
-
-    public static Method getMethod(Class clazz, String methodName, Class... parameterType) {
-        final Method[] methods = clazz.getDeclaredMethods();
-        for (Method method : methods) {
-            if (method.getName().equals(methodName) && method.getParameterTypes().length ==
-                    parameterType.length) {
-                for (int i = 0; i < parameterType.length; i++) {
-                    if (method.getParameterTypes()[i] == parameterType[i]) {
-                        if (i == method.getParameterTypes().length - 1) {
-                            method.setAccessible(true);
-                            return method;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-        return null;
     }
 }
 


### PR DESCRIPTION
## Description of the change

- Remove unused `getMethod` in Android UI tests

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
