### PR TITLE
[MOB-10329] Fix non-working String Keys on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Adds BugReporting.setVideoRecordingFloatingButtonPosition API
+* Fixes an issue with some string keys not working on Android
 
 ## 11.2.0 (2022-09-08)
 

--- a/android/src/main/java/com/instabug/flutter/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/flutter/ArgsRegistry.java
@@ -74,17 +74,14 @@ final class ArgsRegistry {
      * - {@code key} is not null
      * - {@code key} does exist in the registry
      * - The value assigned to the {@code key} is not null
-     * - The value assigned to the {@code key} is assignable from and can be casted to {@code clazz}
-     * (i.e. Foo value = getDeserializedValue("key", Foo.class))
      *
      * @param key   the key whose associated value is to be returned
-     * @param clazz the type in which the value should be deserialized to
      * @return the value deserialized if all the assertions were successful, null otherwise
      */
-    static <T> T getDeserializedValue(String key, Class<T> clazz) {
+    static <T> T getDeserializedValue(String key) {
         if (key != null && ARGS.containsKey(key)) {
             Object constant = ARGS.get(key);
-            if (constant != null && constant.getClass().isAssignableFrom(clazz)) {
+            if (constant != null) {
                 return (T) constant;
             }
         }

--- a/android/src/main/java/com/instabug/flutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/flutter/InstabugFlutterPlugin.java
@@ -159,7 +159,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
         InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[invocationEvents.size()];
         for (int i = 0; i < invocationEvents.size(); i++) {
             String key = invocationEvents.get(i);
-            invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key, InstabugInvocationEvent.class);
+            invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key);
         }
 
         final Application application = (Application) context;
@@ -177,8 +177,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      *                           beta.
      */
     public void showWelcomeMessageWithMode(String welcomeMessageMode) {
-        WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(welcomeMessageMode,
-                WelcomeMessage.State.class);
+        WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(welcomeMessageMode);
         Instabug.showWelcomeMessage(resolvedWelcomeMessageMode);
     }
 
@@ -207,7 +206,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      * @param instabugLocale
      */
     public void setLocale(String instabugLocale) {
-        Locale resolvedLocale = ArgsRegistry.getDeserializedValue(instabugLocale, Locale.class);
+        Locale resolvedLocale = ArgsRegistry.getDeserializedValue(instabugLocale);
         Instabug.setLocale(resolvedLocale);
     }
 
@@ -279,7 +278,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      * @param colorTheme an InstabugColorTheme to set the SDK's UI to.
      */
     public void setColorTheme(String colorTheme) {
-        InstabugColorTheme resolvedTheme = ArgsRegistry.getDeserializedValue(colorTheme, InstabugColorTheme.class);
+        InstabugColorTheme resolvedTheme = ArgsRegistry.getDeserializedValue(colorTheme);
         if (resolvedTheme != null) {
             Instabug.setColorTheme(resolvedTheme);
         }
@@ -292,8 +291,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      * @param floatingButtonOffset  offset for the position on the y-axis.
      */
     public void setFloatingButtonEdge(String floatingButtonEdge, int floatingButtonOffset) {
-        InstabugFloatingButtonEdge resolvedFloatingButtonEdge = ArgsRegistry.getDeserializedValue(floatingButtonEdge,
-                InstabugFloatingButtonEdge.class);
+        InstabugFloatingButtonEdge resolvedFloatingButtonEdge = ArgsRegistry.getDeserializedValue(floatingButtonEdge);
         BugReporting.setFloatingButtonEdge(resolvedFloatingButtonEdge);
         BugReporting.setFloatingButtonOffset(floatingButtonOffset);
     }
@@ -304,7 +302,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      * @param videoRecordingButtonPosition position of the video recording floating button on the screen.
      */
     public void setVideoRecordingFloatingButtonPosition(String videoRecordingButtonPosition) {
-        InstabugVideoRecordingButtonPosition resolvedVideoRecordingButtonPosition = ArgsRegistry.getDeserializedValue(videoRecordingButtonPosition, InstabugVideoRecordingButtonPosition.class);
+        InstabugVideoRecordingButtonPosition resolvedVideoRecordingButtonPosition = ArgsRegistry.getDeserializedValue(videoRecordingButtonPosition);
         BugReporting.setVideoRecordingFloatingButtonPosition(resolvedVideoRecordingButtonPosition);
     }
 
@@ -432,8 +430,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      * @param forStringWithKey Key of string to override.
      */
     public void setValue(String value, String forStringWithKey) {
-        InstabugCustomTextPlaceHolder.Key key = ArgsRegistry.getDeserializedValue(forStringWithKey,
-                InstabugCustomTextPlaceHolder.Key.class);
+        InstabugCustomTextPlaceHolder.Key key = ArgsRegistry.getDeserializedValue(forStringWithKey);
         placeHolder.set(key, value);
         Instabug.setCustomTextPlaceHolders(placeHolder);
     }
@@ -560,8 +557,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      *                           beta or disabled.
      */
     public void setWelcomeMessageMode(String welcomeMessageMode) {
-        WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(welcomeMessageMode,
-                WelcomeMessage.State.class);
+        WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(welcomeMessageMode);
         Instabug.setWelcomeMessageState(resolvedWelcomeMessageMode);
     }
 
@@ -627,7 +623,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
                 InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[invocationEvents.size()];
                 for (int i = 0; i < invocationEvents.size(); i++) {
                     String key = invocationEvents.get(i);
-                    invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key, InstabugInvocationEvent.class);
+                    invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key);
                 }
                 BugReporting.setInvocationEvents(invocationEventsArray);
             }
@@ -663,7 +659,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
                 int[] reportTypesArray = new int[reportTypes.size()];
                 for (int i = 0; i < reportTypes.size(); i++) {
                     String key = reportTypes.get(i);
-                    reportTypesArray[i] = ArgsRegistry.getDeserializedValue(key, Integer.class);
+                    reportTypesArray[i] = ArgsRegistry.getDeserializedValue(key);
                 }
                 BugReporting.setReportTypes(reportTypesArray);
             }
@@ -677,8 +673,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      * @param extendedBugReportMode
      */
     public void setExtendedBugReportMode(String extendedBugReportMode) {
-        ExtendedBugReport.State extendedBugReport = ArgsRegistry.getDeserializedValue(extendedBugReportMode,
-                ExtendedBugReport.State.class);
+        ExtendedBugReport.State extendedBugReport = ArgsRegistry.getDeserializedValue(extendedBugReportMode);
         BugReporting.setExtendedBugReportState(extendedBugReport);
     }
 
@@ -690,7 +685,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
     public void setInvocationOptions(List<String> invocationOptions) {
         int[] options = new int[invocationOptions.size()];
         for (int i = 0; i < invocationOptions.size(); i++) {
-            options[i] = ArgsRegistry.getDeserializedValue(invocationOptions.get(i), Integer.class);
+            options[i] = ArgsRegistry.getDeserializedValue(invocationOptions.get(i));
         }
         BugReporting.setOptions(options);
     }
@@ -705,9 +700,9 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
             final List<String> invocationOptions) {
         int[] options = new int[invocationOptions.size()];
         for (int i = 0; i < invocationOptions.size(); i++) {
-            options[i] = ArgsRegistry.getDeserializedValue(invocationOptions.get(i), Integer.class);
+            options[i] = ArgsRegistry.getDeserializedValue(invocationOptions.get(i));
         }
-        int reportTypeInt = ArgsRegistry.getDeserializedValue(reportType, Integer.class);
+        int reportTypeInt = ArgsRegistry.getDeserializedValue(reportType);
         BugReporting.show(reportTypeInt, options);
     }
 
@@ -843,7 +838,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
     public void setEmailFieldRequiredForFeatureRequests(final Boolean isEmailRequired, final List<String> actionTypes) {
         int[] actions = new int[actionTypes.size()];
         for (int i = 0; i < actionTypes.size(); i++) {
-            actions[i] = ArgsRegistry.getDeserializedValue(actionTypes.get(i), Integer.class);
+            actions[i] = ArgsRegistry.getDeserializedValue(actionTypes.get(i));
         }
         FeatureRequests.setEmailFieldRequired(isEmailRequired, actions);
     }
@@ -1015,7 +1010,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
             @Override
             public void run() {
                 try {
-                    if (ArgsRegistry.getDeserializedValue(logLevel, Integer.class) == null) {
+                    if (ArgsRegistry.getDeserializedValue(logLevel) == null) {
                         return;
                     }
                     APM.setLogLevel((int) ArgsRegistry.getRawValue(logLevel));
@@ -1251,7 +1246,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler, FlutterPlugin {
      */
     public void setReproStepsMode(String reproStepsMode) {
         try {
-            Instabug.setReproStepsState(ArgsRegistry.getDeserializedValue(reproStepsMode, State.class));
+            Instabug.setReproStepsState(ArgsRegistry.getDeserializedValue(reproStepsMode));
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
@@ -67,7 +67,7 @@ public class ArgsRegistryTest {
     public void givenFabInvocationIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
         // when
         InstabugInvocationEvent deserializedValue = ArgsRegistry.getDeserializedValue(
-                "InvocationEvent.floatingButton", InstabugInvocationEvent.class);
+                "InvocationEvent.floatingButton");
         // then
         Assert.assertNotNull(deserializedValue);
         Assert.assertEquals(InstabugInvocationEvent.FLOATING_BUTTON, deserializedValue);
@@ -77,7 +77,7 @@ public class ArgsRegistryTest {
     public void givenWelcomeMessageBetaIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
         // when
         WelcomeMessage.State deserializedValue = ArgsRegistry.getDeserializedValue(
-                "WelcomeMessageMode.beta", WelcomeMessage.State.class);
+                "WelcomeMessageMode.beta");
         // then
         Assert.assertNotNull(deserializedValue);
         Assert.assertEquals(WelcomeMessage.State.BETA, deserializedValue);
@@ -86,7 +86,7 @@ public class ArgsRegistryTest {
     @Test
     public void givenEnglishLocaleIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
         // when
-        Locale actualLocale = ArgsRegistry.getDeserializedValue("IBGLocale.english", Locale.class);
+        Locale actualLocale = ArgsRegistry.getDeserializedValue("IBGLocale.english");
         // then
         Assert.assertNotNull(actualLocale);
         Assert.assertEquals("en", actualLocale.getLanguage());
@@ -105,8 +105,8 @@ public class ArgsRegistryTest {
     @Test
     public void givenShakeHintIsPresent_when$getDeserializedValue_thenShouldReturnNonNullKey() {
         // when
-        InstabugCustomTextPlaceHolder.Key actualKey =
-                ArgsRegistry.getDeserializedValue("CustomTextPlaceHolderKey.shakeHint", InstabugCustomTextPlaceHolder.Key.class);
+        InstabugCustomTextPlaceHolder.Key actualKey = ArgsRegistry
+                .getDeserializedValue("CustomTextPlaceHolderKey.shakeHint");
         // then
         Assert.assertNotNull(actualKey);
         Assert.assertEquals(InstabugCustomTextPlaceHolder.Key.SHAKE_HINT, actualKey);
@@ -147,8 +147,6 @@ public class ArgsRegistryTest {
         Assert.assertTrue(map.containsValue(WelcomeMessage.State.BETA));
         Assert.assertTrue(map.containsValue(WelcomeMessage.State.DISABLED));
     }
-
-
 
     private void assertAllSupportedLocalesArePresent(Map<String, Object> map) {
         // source of truth
@@ -193,7 +191,8 @@ public class ArgsRegistryTest {
         Assert.assertTrue(map.containsValue(Option.EMAIL_FIELD_OPTIONAL));
     }
 
-    private void assertAllSupportedCustomTextPlaceHolderKeysArePresent(Map<String, Object> map, List<InstabugCustomTextPlaceHolder.Key> expectedKeys) {
+    private void assertAllSupportedCustomTextPlaceHolderKeysArePresent(Map<String, Object> map,
+            List<InstabugCustomTextPlaceHolder.Key> expectedKeys) {
         // actual
         List<InstabugCustomTextPlaceHolder.Key> actualKeys = new ArrayList<>();
         for (Map.Entry m : map.entrySet()) {


### PR DESCRIPTION
## Description of the change
### Problem:
We have an issue with some string keys not working on Android. The reason is that for these keys, `getDeserializedValue` returns `null` due to the expression `constant.getClass().isAssignableFrom(clazz)` evaluating to `false`. This happens with the keys having `charLimit` method overridden on the native side. 
### Solution:
Remove Class parameter in `getDeserializedValue` method and its check
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
