### PR TITLE
[MOB-10001] Remove Media Projection from Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Bumps Instabug Android SDK to v11.6.0
 * Enables Repro Steps screenshots on Android
-* Removes "Media Projection" dialog from Android
+* Removes "Media Projection" dialog while taking screenshots on Android
 * Adds BugReporting.setDisclaimerText API
 * Adds BugReporting.setCommentMinimumCharacterCount API
 * Deprecates Instabug.enableAndroid and Instabug.disableAndroid APIs in favour of a new API Instabug.setEnabled, which works on both platforms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Bumps Instabug Android SDK to v11.6.0
+* Enables Repro Steps screenshots on Android
+* Removes "Media Projection" dialog from Android
 * Adds BugReporting.setDisclaimerText API
 * Adds BugReporting.setCommentMinimumCharacterCount API
 * Deprecates Instabug.enableAndroid and Instabug.disableAndroid APIs in favour of a new API Instabug.setEnabled, which works on both platforms

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Repro Steps list all of the actions an app user took before reporting a bug or c
   ));
   ```
 
-⚠️  Screenshots in repro steps on android is not currently supported.
 
 ## Network Logging
 You can choose to attach all your network requests to the reports being sent to the dashboard. To enable the feature when using the `dart:io` package `HttpClient`, please refer to the [Instabug Dart IO Http Client](https://github.com/Instabug/instabug-dart-io-http-client) repository.

--- a/android/src/main/java/com/instabug/flutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/flutter/InstabugFlutterPlugin.java
@@ -1,8 +1,14 @@
 package com.instabug.flutter;
 
+import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.util.Log;
+import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.instabug.flutter.modules.ApmApi;
 import com.instabug.flutter.modules.BugReportingApi;
@@ -13,36 +19,92 @@ import com.instabug.flutter.modules.InstabugLogApi;
 import com.instabug.flutter.modules.RepliesApi;
 import com.instabug.flutter.modules.SurveysApi;
 
+import java.util.concurrent.Callable;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
-public class InstabugFlutterPlugin implements FlutterPlugin {
+public class InstabugFlutterPlugin implements FlutterPlugin, ActivityAware {
+    private static final String TAG = InstabugFlutterPlugin.class.getName();
+
+    @SuppressLint("StaticFieldLeak")
+    private static Activity activity;
+
     /**
      * Embedding v1
      */
     @SuppressWarnings("deprecation")
     public static void registerWith(Registrar registrar) {
-        register(registrar.context().getApplicationContext(), registrar.messenger());
+        activity = registrar.activity();
+        register(registrar.context().getApplicationContext(), registrar.messenger(), (FlutterRenderer) registrar.textures());
     }
 
-    private static void register(Context context, BinaryMessenger messenger) {
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+        register(binding.getApplicationContext(), binding.getBinaryMessenger(), (FlutterRenderer) binding.getTextureRegistry());
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        activity = null;
+    }
+
+    @Override
+    public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+        activity = binding.getActivity();
+    }
+
+    @Override
+    public void onDetachedFromActivityForConfigChanges() {
+        activity = null;
+    }
+
+    @Override
+    public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+        activity = binding.getActivity();
+    }
+
+    @Override
+    public void onDetachedFromActivity() {
+        activity = null;
+    }
+
+    private static void register(Context context, BinaryMessenger messenger, FlutterRenderer renderer) {
+        final Callable<Bitmap> screenshotProvider = new Callable<Bitmap>() {
+            @Override
+            public Bitmap call() {
+                return takeScreenshot(renderer);
+            }
+        };
+
         ApmApi.init(messenger);
         BugReportingApi.init(messenger);
         CrashReportingApi.init(messenger);
         FeatureRequestsApi.init(messenger);
-        InstabugApi.init(messenger, context);
+        InstabugApi.init(messenger, context, screenshotProvider);
         InstabugLogApi.init(messenger);
         RepliesApi.init(messenger);
         SurveysApi.init(messenger);
     }
 
-    @Override
-    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-        register(binding.getApplicationContext(), binding.getBinaryMessenger());
-    }
+    @Nullable
+    private static Bitmap takeScreenshot(FlutterRenderer renderer) {
+        try {
+            final View view = activity.getWindow().getDecorView().getRootView();
 
-    @Override
-    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+            view.setDrawingCacheEnabled(true);
+            final Bitmap bitmap = renderer.getBitmap();
+            Log.v(TAG, bitmap.toString());
+            view.setDrawingCacheEnabled(false);
+
+            return bitmap;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to take screenshot using " + renderer.toString() + ". Cause: " + e);
+            return null;
+        }
     }
 }

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -1,6 +1,5 @@
 package com.instabug.flutter.modules;
 
-import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -9,9 +8,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
-import com.instabug.bug.BugReporting;
+import com.instabug.flutter.util.ArgsRegistry;
 import com.instabug.flutter.generated.InstabugPigeon;
 import com.instabug.flutter.util.ArgsRegistry;
 import com.instabug.flutter.util.Reflection;
@@ -33,30 +31,24 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 public class InstabugApi implements InstabugPigeon.InstabugHostApi {
     private final String TAG = InstabugApi.class.getName();
     private final Context context;
+    private final Callable<Bitmap> screenshotProvider;
     private final InstabugCustomTextPlaceHolder placeHolder = new InstabugCustomTextPlaceHolder();
 
-    public static void init(BinaryMessenger messenger, Context context) {
-        final InstabugApi api = new InstabugApi(context);
+    public static void init(BinaryMessenger messenger, Context context, Callable<Bitmap> screenshotProvider) {
+        final InstabugApi api = new InstabugApi(context, screenshotProvider);
         InstabugPigeon.InstabugHostApi.setup(messenger, api);
     }
 
-    public InstabugApi(Context context) {
+    public InstabugApi(Context context, Callable<Bitmap> screenshotProvider) {
         this.context = context;
-    }
-
-    /**
-     * Enables taking screenshots by media projection.
-     */
-    @SuppressLint("NewApi")
-    @VisibleForTesting
-    public static void enableScreenShotByMediaProjection(boolean isEnabled) {
-        BugReporting.setScreenshotByMediaProjectionEnabled(isEnabled);
+        this.screenshotProvider = screenshotProvider;
     }
 
     private void setCurrentPlatform() {
@@ -98,8 +90,7 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         new Instabug.Builder(application, token)
                 .setInvocationEvents(invocationEventsArray)
                 .build();
-
-        enableScreenShotByMediaProjection(true);
+        Instabug.setScreenshotProvider(screenshotProvider);
     }
 
     @Override

--- a/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
+++ b/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
@@ -11,7 +11,7 @@ import org.mockito.MockedStatic;
 
 
 public class InstabugApiTest extends TestCase {
-    private final InstabugApi mApi = new InstabugApi(null);
+    private final InstabugApi mApi = new InstabugApi(null, null);
     private final MockedStatic<Instabug> mInstabug = mockStatic(Instabug.class);
 
     public void testLogOut() {

--- a/e2e/BugReporting.cs
+++ b/e2e/BugReporting.cs
@@ -20,8 +20,6 @@ public class BugReporting
         ios: "IBGFloatingButtonAccessibilityIdentifier"
     ).Tap();
 
-    if (captain.IsAndroid) captain.GoBack();
-
     captain.FindByText("Report a bug").Tap();
 
     captain.FindInput(

--- a/example/android/app/src/androidTest/java/com/example/InstabugSample/InvokeInstabugUITest.java
+++ b/example/android/app/src/androidTest/java/com/example/InstabugSample/InvokeInstabugUITest.java
@@ -33,11 +33,6 @@ public class InvokeInstabugUITest {
         onView(withResourceName("instabug_floating_button")).perform(click());
         Thread.sleep(1000);
 
-        // Dismiss media projection prompt.
-        // This is a temporary solution as we are dropping media projection in a future release.
-        device.pressBack();
-        Thread.sleep(1000);
-
         onView(withText("Report a bug")).perform(click());
         Thread.sleep(1000);
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,6 +20,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
+      navigatorObservers: [
+        InstabugNavigatorObserver(),
+      ],
       theme: ThemeData(
         // This is the theme of your application.
         //


### PR DESCRIPTION
## Description of the change

When invoking Instabug on Android, a ["scary" dialog](https://github.com/Instabug/Instabug-Flutter/issues/251) appears, asking for permission to record screen. This was due to the way we captured screenshots on Android, using [Media Projection](https://developer.android.com/reference/android/media/projection/MediaProjection), since other alternatives didn't work with Flutter.

This PR aims at providing an alternative approach for Media Projection, using [`FlutterRenderer`](https://api.flutter.dev/javadoc/io/flutter/embedding/engine/renderer/FlutterRenderer.html) to capture screenshots. This implicitly fixes [Repro Steps](https://docs.instabug.com/docs/flutter-repro-steps) on Android as well.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
