### PR TITLE
[MOB-9125] Fix Main Thread Violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Fixes main thread violation on Android
 * Fixes an issue with request and response headers parameters type causing network requests not getting logged on iOS
 * Uses pigeon for internal communication between Flutter and the host platform
 

--- a/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
@@ -1,7 +1,5 @@
 package com.instabug.flutter.modules;
 
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -33,61 +31,41 @@ public class ApmApi implements ApmPigeon.ApmHostApi {
 
     @Override
     public void setEnabled(@NonNull Boolean isEnabled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    APM.setEnabled(isEnabled);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            APM.setEnabled(isEnabled);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void setColdAppLaunchEnabled(@NonNull Boolean isEnabled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    APM.setAppLaunchEnabled(isEnabled);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            APM.setAppLaunchEnabled(isEnabled);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void setAutoUITraceEnabled(@NonNull Boolean isEnabled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    APM.setAutoUITraceEnabled(isEnabled);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            APM.setAutoUITraceEnabled(isEnabled);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void setLogLevel(@NonNull String level) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    if (ArgsRegistry.getDeserializedValue(level) == null) {
-                        return;
-                    }
-                    APM.setLogLevel((int) ArgsRegistry.getRawValue(level));
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+        try {
+            if (ArgsRegistry.getDeserializedValue(level) == null) {
+                return;
             }
-        });
+            APM.setLogLevel((int) ArgsRegistry.getRawValue(level));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Nullable
@@ -109,72 +87,47 @@ public class ApmApi implements ApmPigeon.ApmHostApi {
 
     @Override
     public void setExecutionTraceAttribute(@NonNull String id, @NonNull String key, @NonNull String value) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    traces.get(id).setAttribute(key, value);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            traces.get(id).setAttribute(key, value);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void endExecutionTrace(@NonNull String id) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    traces.get(id).end();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            traces.get(id).end();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void startUITrace(@NonNull String name) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    APM.startUITrace(name);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            APM.startUITrace(name);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void endUITrace() {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    APM.endUITrace();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            APM.endUITrace();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public void endAppLaunch() {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    APM.endAppLaunch();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        try {
+            APM.endAppLaunch();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
@@ -1,8 +1,5 @@
 package com.instabug.flutter.modules;
 
-import android.os.Handler;
-import android.os.Looper;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -36,16 +33,11 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
 
     @Override
     public void setEnabled(@NonNull Boolean isEnabled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                if (isEnabled) {
-                    BugReporting.setState(Feature.State.ENABLED);
-                } else {
-                    BugReporting.setState(Feature.State.DISABLED);
-                }
-            }
-        });
+        if (isEnabled) {
+            BugReporting.setState(Feature.State.ENABLED);
+        } else {
+            BugReporting.setState(Feature.State.DISABLED);
+        }
     }
 
     @Override
@@ -60,32 +52,26 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
 
     @Override
     public void setInvocationEvents(@NonNull List<String> events) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[events.size()];
-                for (int i = 0; i < events.size(); i++) {
-                    String key = events.get(i);
-                    invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key);
-                }
-                BugReporting.setInvocationEvents(invocationEventsArray);
-            }
-        });
+        InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[events.size()];
+
+        for (int i = 0; i < events.size(); i++) {
+            String key = events.get(i);
+            invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key);
+        }
+
+        BugReporting.setInvocationEvents(invocationEventsArray);
     }
 
     @Override
     public void setReportTypes(@NonNull List<String> types) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                int[] reportTypesArray = new int[types.size()];
-                for (int i = 0; i < types.size(); i++) {
-                    String key = types.get(i);
-                    reportTypesArray[i] = ArgsRegistry.getDeserializedValue(key);
-                }
-                BugReporting.setReportTypes(reportTypesArray);
-            }
-        });
+        int[] reportTypesArray = new int[types.size()];
+
+        for (int i = 0; i < types.size(); i++) {
+            String key = types.get(i);
+            reportTypesArray[i] = ArgsRegistry.getDeserializedValue(key);
+        }
+
+        BugReporting.setReportTypes(reportTypesArray);
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/CrashReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/CrashReportingApi.java
@@ -1,7 +1,5 @@
 package com.instabug.flutter.modules;
 
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -27,35 +25,26 @@ public class CrashReportingApi implements CrashReportingPigeon.CrashReportingHos
 
     @Override
     public void setEnabled(@NonNull Boolean isEnabled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                if (isEnabled) {
-                    CrashReporting.setState(Feature.State.ENABLED);
-                } else {
-                    CrashReporting.setState(Feature.State.DISABLED);
-                }
-            }
-        });
+        if (isEnabled) {
+            CrashReporting.setState(Feature.State.ENABLED);
+        } else {
+            CrashReporting.setState(Feature.State.DISABLED);
+        }
     }
 
     @Override
     public void send(@NonNull String jsonCrash, @NonNull Boolean isHandled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    final JSONObject exceptionObject = new JSONObject(jsonCrash);
-                    Method method = Reflection.getMethod(Class.forName("com.instabug.crash.CrashReporting"), "reportException",
-                            JSONObject.class, boolean.class);
-                    if (method != null) {
-                        method.invoke(null, exceptionObject, isHandled);
-                        Log.e(TAG, exceptionObject.toString());
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+        try {
+            final JSONObject exceptionObject = new JSONObject(jsonCrash);
+            Method method = Reflection.getMethod(Class.forName("com.instabug.crash.CrashReporting"), "reportException",
+                    JSONObject.class, boolean.class);
+            if (method != null) {
+                method.invoke(null, exceptionObject, isHandled);
+                Log.e(TAG, exceptionObject.toString());
             }
-        });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
+
 }

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -5,8 +5,6 @@ import android.app.Application;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -93,8 +91,7 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
     @Override
     public void show() {
-        Handler handler = new Handler(Looper.getMainLooper());
-        handler.post(Instabug::show);
+        Instabug.show();
     }
 
     @Override
@@ -145,12 +142,7 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
     @Override
     public void setPrimaryColor(@NonNull Long color) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                Instabug.setPrimaryColor(color.intValue());
-            }
-        });
+        Instabug.setPrimaryColor(color.intValue());
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -15,6 +15,7 @@ import com.instabug.bug.BugReporting;
 import com.instabug.flutter.generated.InstabugPigeon;
 import com.instabug.flutter.util.ArgsRegistry;
 import com.instabug.flutter.util.Reflection;
+import com.instabug.flutter.util.ThreadManager;
 import com.instabug.library.Feature;
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
@@ -171,10 +172,16 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         Instabug.resetTags();
     }
 
-    @Nullable
     @Override
-    public List<String> getTags() {
-        return Instabug.getTags();
+    public void getTags(InstabugPigeon.Result<List<String>> result) {
+        ThreadManager.runOnBackground(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        result.success(Instabug.getTags());
+                    }
+                }
+        );
     }
 
     @Override
@@ -202,16 +209,29 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         Instabug.removeUserAttribute(key);
     }
 
-    @Nullable
+
     @Override
-    public String getUserAttributeForKey(@NonNull String key) {
-        return Instabug.getUserAttribute(key);
+    public void getUserAttributeForKey(@NonNull String key, InstabugPigeon.Result<String> result) {
+        ThreadManager.runOnBackground(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        result.success(Instabug.getUserAttribute(key));
+                    }
+                }
+        );
     }
 
-    @Nullable
     @Override
-    public Map<String, String> getUserAttributes() {
-        return Instabug.getAllUserAttributes();
+    public void getUserAttributes(InstabugPigeon.Result<Map<String, String>> result) {
+        ThreadManager.runOnBackground(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        result.success(Instabug.getAllUserAttributes());
+                    }
+                }
+        );
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/RepliesApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/RepliesApi.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 
 import com.instabug.chat.Replies;
 import com.instabug.flutter.generated.RepliesPigeon;
+import com.instabug.flutter.util.ThreadManager;
 import com.instabug.library.Feature;
 
 import io.flutter.plugin.common.BinaryMessenger;
@@ -45,16 +46,28 @@ public class RepliesApi implements RepliesPigeon.RepliesHostApi {
         Replies.setInAppNotificationSound(isEnabled);
     }
 
-    @NonNull
     @Override
-    public Long getUnreadRepliesCount() {
-        return (long) Replies.getUnreadRepliesCount();
+    public void getUnreadRepliesCount(RepliesPigeon.Result<Long> result) {
+        ThreadManager.runOnBackground(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        result.success((long) Replies.getUnreadRepliesCount());
+                    }
+                }
+        );
     }
 
-    @NonNull
     @Override
-    public Boolean hasChats() {
-        return Replies.hasChats();
+    public void hasChats(RepliesPigeon.Result<Boolean> result) {
+        ThreadManager.runOnBackground(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        result.success(Replies.hasChats());
+                    }
+                }
+        );
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/RepliesApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/RepliesApi.java
@@ -1,8 +1,5 @@
 package com.instabug.flutter.modules;
 
-import android.os.Handler;
-import android.os.Looper;
-
 import androidx.annotation.NonNull;
 
 import com.instabug.chat.Replies;
@@ -26,16 +23,11 @@ public class RepliesApi implements RepliesPigeon.RepliesHostApi {
 
     @Override
     public void setEnabled(@NonNull Boolean isEnabled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                if (isEnabled) {
-                    Replies.setState(Feature.State.ENABLED);
-                } else {
-                    Replies.setState(Feature.State.DISABLED);
-                }
-            }
-        });
+        if (isEnabled) {
+            Replies.setState(Feature.State.ENABLED);
+        } else {
+            Replies.setState(Feature.State.DISABLED);
+        }
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
@@ -3,6 +3,7 @@ package com.instabug.flutter.modules;
 import androidx.annotation.NonNull;
 
 import com.instabug.flutter.generated.SurveysPigeon;
+import com.instabug.flutter.util.ThreadManager;
 import com.instabug.library.Feature;
 import com.instabug.survey.Survey;
 import com.instabug.survey.Surveys;
@@ -63,20 +64,34 @@ public class SurveysApi implements SurveysPigeon.SurveysHostApi {
 
     @Override
     public void hasRespondedToSurvey(@NonNull String surveyToken, SurveysPigeon.Result<Boolean> result) {
-        final boolean hasResponded = Surveys.hasRespondToSurvey(surveyToken);
-        result.success(hasResponded);
+        ThreadManager.runOnBackground(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        final boolean hasResponded = Surveys.hasRespondToSurvey(surveyToken);
+                        result.success(hasResponded);
+                    }
+                }
+        );
     }
 
     @Override
     public void getAvailableSurveys(SurveysPigeon.Result<List<String>> result) {
-        List<Survey> surveys = Surveys.getAvailableSurveys();
+        ThreadManager.runOnBackground(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        List<Survey> surveys = Surveys.getAvailableSurveys();
 
-        ArrayList<String> titles = new ArrayList<>();
-        for (Survey survey : surveys != null ? surveys : new ArrayList<Survey>()) {
-            titles.add(survey.getTitle());
-        }
+                        ArrayList<String> titles = new ArrayList<>();
+                        for (Survey survey : surveys != null ? surveys : new ArrayList<Survey>()) {
+                            titles.add(survey.getTitle());
+                        }
 
-        result.success(titles);
+                        result.success(titles);
+                    }
+                }
+        );
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
@@ -1,8 +1,5 @@
 package com.instabug.flutter.modules;
 
-import android.os.Handler;
-import android.os.Looper;
-
 import androidx.annotation.NonNull;
 
 import com.instabug.flutter.generated.SurveysPigeon;
@@ -32,16 +29,11 @@ public class SurveysApi implements SurveysPigeon.SurveysHostApi {
 
     @Override
     public void setEnabled(@NonNull Boolean isEnabled) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                if (isEnabled) {
-                    Surveys.setState(Feature.State.ENABLED);
-                } else {
-                    Surveys.setState(Feature.State.DISABLED);
-                }
-            }
-        });
+        if (isEnabled) {
+            Surveys.setState(Feature.State.ENABLED);
+        } else {
+            Surveys.setState(Feature.State.DISABLED);
+        }
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/util/ThreadManager.java
+++ b/android/src/main/java/com/instabug/flutter/util/ThreadManager.java
@@ -1,0 +1,10 @@
+package com.instabug.flutter.util;
+
+import android.os.AsyncTask;
+
+public class ThreadManager {
+    // TODO: migrate to Flutter's TaskQueue
+    public static void runOnBackground(Runnable runnable) {
+        AsyncTask.execute(runnable);
+    }
+}

--- a/ios/Classes/Modules/ApmApi.m
+++ b/ios/Classes/Modules/ApmApi.m
@@ -34,14 +34,14 @@ NSMutableDictionary *traces;
     IBGAPM.logLevel = resolvedLevel;
 }
 
-- (nullable NSString *)startExecutionTraceId:(NSString *)id name:(NSString *)name error:(FlutterError *_Nullable *_Nonnull)error {
+- (void)startExecutionTraceId:(NSString *)id name:(NSString *)name completion:(void(^)(NSString *_Nullable, FlutterError *_Nullable))completion {
     IBGExecutionTrace *trace = [IBGAPM startExecutionTraceWithName:name];
 
     if (trace != nil) {
         [traces setObject:trace forKey:id];
-        return id;
+        return completion(id, nil);
     } else {
-        return nil;
+        return completion(nil, nil);
     }
 }
 

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -98,8 +98,8 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
     [Instabug resetTags];
 }
 
-- (nullable NSArray<NSString *> *)getTagsWithError:(FlutterError *_Nullable *_Nonnull)error {
-    return [Instabug getTags];
+- (void)getTagsWithCompletion:(nonnull void (^)(NSArray<NSString *> * _Nullable, FlutterError * _Nullable))completion {
+    completion([Instabug getTags], nil);
 }
 
 - (void)addExperimentsExperiments:(NSArray<NSString *> *)experiments error:(FlutterError *_Nullable *_Nonnull)error {
@@ -122,12 +122,12 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
     [Instabug removeUserAttributeForKey:key];
 }
 
-- (nullable NSString *)getUserAttributeForKeyKey:(NSString *)key error:(FlutterError *_Nullable *_Nonnull)error {
-    return [Instabug userAttributeForKey:key];
+- (void)getUserAttributeForKeyKey:(nonnull NSString *)key completion:(nonnull void (^)(NSString * _Nullable, FlutterError * _Nullable))completion {
+    completion([Instabug userAttributeForKey:key], nil);
 }
 
-- (nullable NSDictionary<NSString *, NSString *> *)getUserAttributesWithError:(FlutterError *_Nullable *_Nonnull)error {
-    return Instabug.userAttributes;
+- (void)getUserAttributesWithCompletion:(nonnull void (^)(NSDictionary<NSString *,NSString *> * _Nullable, FlutterError * _Nullable))completion {
+    completion(Instabug.userAttributes, nil);
 }
 
 - (void)setDebugEnabledEnabled:(NSNumber *)enabled error:(FlutterError *_Nullable *_Nonnull)error {

--- a/ios/Classes/Modules/RepliesApi.m
+++ b/ios/Classes/Modules/RepliesApi.m
@@ -33,12 +33,12 @@ extern void InitRepliesApi(id<FlutterBinaryMessenger> messenger) {
     // Android Only
 }
 
-- (nullable NSNumber *)getUnreadRepliesCountWithError:(FlutterError *_Nullable *_Nonnull)error {
-    return [NSNumber numberWithLong:IBGReplies.unreadRepliesCount];
+- (void)getUnreadRepliesCountWithCompletion:(nonnull void (^)(NSNumber * _Nullable, FlutterError * _Nullable))completion {
+    completion([NSNumber numberWithLong:IBGReplies.unreadRepliesCount], nil);
 }
 
-- (nullable NSNumber *)hasChatsWithError:(FlutterError *_Nullable *_Nonnull)error {
-    return [NSNumber numberWithBool:IBGReplies.hasChats];
+- (void)hasChatsWithCompletion:(nonnull void (^)(NSNumber * _Nullable, FlutterError * _Nullable))completion {
+    completion([NSNumber numberWithBool:IBGReplies.hasChats], nil);
 }
 
 - (void)bindOnNewReplyCallbackWithError:(FlutterError *_Nullable *_Nonnull)error {

--- a/pigeons/apm.api.dart
+++ b/pigeons/apm.api.dart
@@ -6,7 +6,10 @@ abstract class ApmHostApi {
   void setColdAppLaunchEnabled(bool isEnabled);
   void setAutoUITraceEnabled(bool isEnabled);
   void setLogLevel(String level);
+
+  @async
   String? startExecutionTrace(String id, String name);
+
   void setExecutionTraceAttribute(
     String id,
     String key,

--- a/pigeons/instabug.api.dart
+++ b/pigeons/instabug.api.dart
@@ -21,6 +21,8 @@ abstract class InstabugHostApi {
 
   void appendTags(List<String> tags);
   void resetTags();
+
+  @async
   List<String>? getTags();
 
   void addExperiments(List<String> experiments);
@@ -29,7 +31,11 @@ abstract class InstabugHostApi {
 
   void setUserAttribute(String value, String key);
   void removeUserAttribute(String key);
+
+  @async
   String? getUserAttributeForKey(String key);
+
+  @async
   Map<String, String>? getUserAttributes();
 
   void setDebugEnabled(bool enabled);

--- a/pigeons/replies.api.dart
+++ b/pigeons/replies.api.dart
@@ -11,7 +11,12 @@ abstract class RepliesHostApi {
   void show();
   void setInAppNotificationsEnabled(bool isEnabled);
   void setInAppNotificationSound(bool isEnabled);
+
+  @async
   int getUnreadRepliesCount();
+
+  @async
   bool hasChats();
+
   void bindOnNewReplyCallback();
 }


### PR DESCRIPTION
## Description of the change

1. Remove main thread wrappers from Android, since [Flutter plugin methods run by default on main thread](https://docs.flutter.dev/development/platform-integration/platform-channels#channels-and-platform-threading).
1. Run Android non-void APIs on background thread, to fix threading violation reported by Instabug Android SDK.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
