### PR TITLE
[MOB-10548] Use Return Values Instead of Callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 * Fixes main thread violation on Android
 * Fixes an issue with request and response headers parameters type causing network requests not getting logged on iOS
 * Uses pigeon for internal communication between Flutter and the host platform
+* Uses return values instead of callbacks in the following APIs:
+  1. Replies.getUnreadRepliesCount
+  2. Replies.hasChats
+  3. Surveys.hasRespondedToSurvey
+  4. Surveys.getAvailableSurveys
 
 ## 11.3.0 (2022-09-30)
 

--- a/lib/src/modules/replies.dart
+++ b/lib/src/modules/replies.dart
@@ -6,8 +6,16 @@ import 'package:instabug_flutter/generated/replies.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:meta/meta.dart';
 
+@Deprecated(
+  "Use [Replies.hasChats] return value instead of callback.",
+)
 typedef HasChatsCallback = void Function(bool);
+
 typedef OnNewReplyReceivedCallback = void Function();
+
+@Deprecated(
+  "Use [Replies.getUnreadRepliesCount] return value instead of callback.",
+)
 typedef UnreadRepliesCountCallback = void Function(int);
 
 class Replies implements RepliesFlutterApi {
@@ -45,10 +53,16 @@ class Replies implements RepliesFlutterApi {
 
   /// Tells whether the user has chats already or not.
   /// [callback] - callback that is invoked if chats exist
-  static Future<void> hasChats(HasChatsCallback callback) async {
-    // TODO: return directly without callback
+  static Future<bool> hasChats([
+    @Deprecated(
+      'Use return value instead of callback: `final count = await Replies.hasChats();`',
+    )
+        // ignore: deprecated_member_use_from_same_package
+        HasChatsCallback? callback,
+  ]) async {
     final hasChats = await _host.hasChats();
-    callback(hasChats);
+    callback?.call(hasChats);
+    return hasChats;
   }
 
   /// Sets a block of code that gets executed when a new message is received.
@@ -65,12 +79,16 @@ class Replies implements RepliesFlutterApi {
   /// has, then possibly notify them about it with your own UI.
   /// [function] callback with argument
   /// Notifications count, or -1 in case the SDK has not been initialized.
-  static Future<void> getUnreadRepliesCount(
-    UnreadRepliesCountCallback callback,
-  ) async {
-    // TODO: return directly without callback
+  static Future<int> getUnreadRepliesCount([
+    @Deprecated(
+      'Use return value instead of callback: `final count = await Replies.getUnreadRepliesCount();`',
+    )
+        // ignore: deprecated_member_use_from_same_package
+        UnreadRepliesCountCallback? callback,
+  ]) async {
     final count = await _host.getUnreadRepliesCount();
-    callback(count);
+    callback?.call(count);
+    return count;
   }
 
   /// Enables/disables showing in-app notifications when the user receives a new message.

--- a/lib/src/modules/surveys.dart
+++ b/lib/src/modules/surveys.dart
@@ -8,7 +8,15 @@ import 'package:meta/meta.dart';
 
 typedef OnShowSurveyCallback = void Function();
 typedef OnDismissSurveyCallback = void Function();
+
+@Deprecated(
+  "Use [Surveys.getAvailableSurveys] return value instead of callback.",
+)
 typedef AvailableSurveysCallback = void Function(List<String>);
+
+@Deprecated(
+  "Use [Surveys.hasRespondedToSurvey] return value instead of callback.",
+)
 typedef HasRespondedToSurveyCallback = void Function(bool);
 
 class Surveys implements SurveysFlutterApi {
@@ -60,12 +68,16 @@ class Surveys implements SurveysFlutterApi {
   /// Returns an array containing the available surveys.
   /// [callback] availableSurveysCallback callback with
   /// argument available surveys
-  static Future<void> getAvailableSurveys(
-    AvailableSurveysCallback callback,
-  ) async {
-    // TODO: return directly without callback
+  static Future<List<String>> getAvailableSurveys([
+    @Deprecated(
+      'Use return value instead of callback: `final surveys = await Surveys.getAvailableSurveys();`',
+    )
+        // ignore: deprecated_member_use_from_same_package
+        AvailableSurveysCallback? callback,
+  ]) async {
     final titles = await _host.getAvailableSurveys();
-    callback(titles.cast<String>());
+    callback?.call(titles.cast<String>());
+    return titles.cast<String>();
   }
 
   /// Sets a block of code to be executed just before the SDK's UI is presented.
@@ -118,13 +130,17 @@ class Surveys implements SurveysFlutterApi {
   /// This block is executed on the UI thread. Could be used for performing any
   /// UI changes  after the survey's UI is dismissed.
   /// [callback]  A callback that gets executed after the survey's UI is dismissed.
-  static Future<void> hasRespondedToSurvey(
-    String surveyToken,
-    HasRespondedToSurveyCallback callback,
-  ) async {
-    // TODO: return directly without callback
+  static Future<bool> hasRespondedToSurvey(
+    String surveyToken, [
+    @Deprecated(
+      'Use return value instead of callback: `final responded = await Surveys.hasRespondedToSurvey("<TOKEN>");`',
+    )
+        // ignore: deprecated_member_use_from_same_package
+        HasRespondedToSurveyCallback? callback,
+  ]) async {
     final hasResponded = await _host.hasRespondedToSurvey(surveyToken);
-    callback(hasResponded);
+    callback?.call(hasResponded);
+    return hasResponded;
   }
 
   /// iOS Only

--- a/test/replies_test.dart
+++ b/test/replies_test.dart
@@ -67,10 +67,9 @@ void main() {
     const count = 10;
     when(mHost.getUnreadRepliesCount()).thenAnswer((_) async => count);
 
-    await Replies.getUnreadRepliesCount((result) {
-      expect(result, count);
-    });
+    final result = await Replies.getUnreadRepliesCount();
 
+    expect(result, count);
     verify(
       mHost.getUnreadRepliesCount(),
     ).called(1);
@@ -80,10 +79,9 @@ void main() {
     const hasChats = true;
     when(mHost.hasChats()).thenAnswer((_) async => hasChats);
 
-    await Replies.hasChats((result) {
-      expect(result, hasChats);
-    });
+    final result = await Replies.hasChats();
 
+    expect(result, hasChats);
     verify(
       mHost.hasChats(),
     ).called(1);

--- a/test/surveys_test.dart
+++ b/test/surveys_test.dart
@@ -88,13 +88,9 @@ void main() {
     const responded = true;
     when(mHost.hasRespondedToSurvey(token)).thenAnswer((_) async => responded);
 
-    await Surveys.hasRespondedToSurvey(
-      token,
-      (result) {
-        expect(result, responded);
-      },
-    );
+    final result = await Surveys.hasRespondedToSurvey(token);
 
+    expect(result, responded);
     verify(
       mHost.hasRespondedToSurvey(token),
     ).called(1);
@@ -104,10 +100,9 @@ void main() {
     const surveys = ["survey-1", "survey-2"];
     when(mHost.getAvailableSurveys()).thenAnswer((_) async => surveys);
 
-    await Surveys.getAvailableSurveys((result) {
-      expect(result, surveys);
-    });
+    final result = await Surveys.getAvailableSurveys();
 
+    expect(result, surveys);
     verify(
       mHost.getAvailableSurveys(),
     ).called(1);


### PR DESCRIPTION
## Description of the change

Some APIs had a callback function which was used to return values of the asynchronous calls. This behaviour was replaced by a return value instead.

#### Example

```dart
// The old callback way (deprecated)
Replies.hasChats((result) => print(result));

// The new return value way
final result = Replies.hasChats();
print(result);
```

#### Affected APIs
 1. `Replies.getUnreadRepliesCount`
 2. `Replies.hasChats`
 3. `Surveys.hasRespondedToSurvey`
 4. `Surveys.getAvailableSurveys`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
