### PR TITLE
[MOB-10569] Pin CI .NET Version to 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             sudo dpkg -i packages-microsoft-prod.deb
             rm packages-microsoft-prod.deb
       - run:
-          name: Install .NET
+          name: Install .NET 6
           command: |
             sudo apt-get update
             sudo apt-get install -y dotnet-sdk-6.0
@@ -140,8 +140,10 @@ jobs:
           working_directory: example
           command: flutter build ios --simulator
       - run:
-          name: Install .NET
-          command: brew install --cask dotnet-sdk
+          name: Install .NET 6
+          command: |
+            brew tap isen-ng/dotnet-sdk-versions
+            brew install --cask dotnet-sdk6-0-400
       - run:
           name: Clone Captain
           command: git clone git@github.com:Instabug/Captain.git ../Instabug.Captain


### PR DESCRIPTION
## Description of the change

Installing latest version of .NET using `brew` caused `e2e_ios_captain` job to **fail**, since it was designed based on .NET 6 and `brew` only fetches the latest version.

This PR uses `isen-ng/homebrew-dotnet-sdk-versions` to install .NET 6 instead of latest version.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
