### PR TITLE
[MOB-10816] Unify Internal Models Style

### DIFF
--- a/lib/src/models/crash_data.dart
+++ b/lib/src/models/crash_data.dart
@@ -1,26 +1,23 @@
 import 'package:instabug_flutter/src/models/exception_data.dart';
 
 class CrashData {
-  CrashData(this.message, this.os, this.exception);
+  const CrashData({
+    required this.os,
+    required this.message,
+    required this.exception,
+  });
 
-  String message;
-  String os;
-  String platform = 'flutter';
-  List<ExceptionData> exception;
+  static const platform = 'flutter';
+  final String message;
+  final String os;
+  final List<ExceptionData> exception;
 
-  Map<String, dynamic> toJson() => <String, dynamic>{
-        'message': message,
-        'os': os,
-        'platform': platform,
-        'exception': exception,
-      };
-
-  Map<String, dynamic> toMap() {
-    final map = <String, dynamic>{};
-    map['message'] = message;
-    map['os'] = os;
-    map['platform'] = platform;
-    map['exception'] = exception;
-    return map;
+  Map<String, dynamic> toJson() {
+    return {
+      'os': os,
+      'message': message,
+      'platform': platform,
+      'exception': exception,
+    };
   }
 }

--- a/lib/src/models/exception_data.dart
+++ b/lib/src/models/exception_data.dart
@@ -1,26 +1,23 @@
 class ExceptionData {
-  const ExceptionData(this.file, this.methodName, this.lineNumber, this.column);
+  const ExceptionData({
+    required this.file,
+    required this.methodName,
+    required this.lineNumber,
+    required this.column,
+  });
 
   final String file;
   final String? methodName;
   final int? lineNumber;
   final int column;
 
-  Map<String, dynamic> toJson() => <String, dynamic>{
-        'file': file,
-        'methodName': methodName,
-        'arguments': <dynamic>[],
-        'lineNumber': lineNumber,
-        'column': column,
-      };
-
-  Map<String, dynamic> toMap() {
-    final map = <String, dynamic>{};
-    map['file'] = file;
-    map['methodName'] = methodName;
-    map['arguments'] = <dynamic>[];
-    map['lineNumber'] = lineNumber;
-    map['column'] = column;
-    return map;
+  Map<String, dynamic> toJson() {
+    return {
+      'file': file,
+      'methodName': methodName,
+      'arguments': <dynamic>[],
+      'lineNumber': lineNumber,
+      'column': column,
+    };
   }
 }

--- a/lib/src/models/network_data.dart
+++ b/lib/src/models/network_data.dart
@@ -52,45 +52,46 @@ class NetworkData {
     DateTime? startTime,
     int? errorCode,
     String? errorDomain,
-  }) =>
-      NetworkData(
-        url: url ?? this.url,
-        method: method ?? this.method,
-        requestBody: requestBody ?? this.requestBody,
-        responseBody: responseBody ?? this.responseBody,
-        requestBodySize: requestBodySize ?? this.requestBodySize,
-        responseBodySize: responseBodySize ?? this.responseBodySize,
-        status: status ?? this.status,
-        requestHeaders: requestHeaders ?? this.requestHeaders,
-        responseHeaders: responseHeaders ?? this.responseHeaders,
-        duration: duration ?? this.duration,
-        requestContentType: requestContentType ?? this.requestContentType,
-        responseContentType: responseContentType ?? this.responseContentType,
-        endTime: endTime ?? this.endTime,
-        startTime: startTime ?? this.startTime,
-        errorCode: errorCode ?? this.errorCode,
-        errorDomain: errorDomain ?? this.errorDomain,
-      );
+  }) {
+    return NetworkData(
+      url: url ?? this.url,
+      method: method ?? this.method,
+      requestBody: requestBody ?? this.requestBody,
+      responseBody: responseBody ?? this.responseBody,
+      requestBodySize: requestBodySize ?? this.requestBodySize,
+      responseBodySize: responseBodySize ?? this.responseBodySize,
+      status: status ?? this.status,
+      requestHeaders: requestHeaders ?? this.requestHeaders,
+      responseHeaders: responseHeaders ?? this.responseHeaders,
+      duration: duration ?? this.duration,
+      requestContentType: requestContentType ?? this.requestContentType,
+      responseContentType: responseContentType ?? this.responseContentType,
+      endTime: endTime ?? this.endTime,
+      startTime: startTime ?? this.startTime,
+      errorCode: errorCode ?? this.errorCode,
+      errorDomain: errorDomain ?? this.errorDomain,
+    );
+  }
 
-  Map<String, dynamic> toMap() {
-    final map = <String, dynamic>{};
-    map['url'] = url;
-    map['method'] = method;
-    map['requestBody'] = requestBody;
-    map['responseBody'] = responseBody;
-    map['responseCode'] = status;
-    map['requestHeaders'] =
-        requestHeaders.map((key, value) => MapEntry(key, value.toString()));
-    map['responseHeaders'] =
-        responseHeaders.map((key, value) => MapEntry(key, value.toString()));
-    map['requestContentType'] = requestContentType;
-    map['responseContentType'] = responseContentType;
-    map['duration'] = duration;
-    map['startTime'] = startTime.millisecondsSinceEpoch;
-    map['requestBodySize'] = requestBodySize;
-    map['responseBodySize'] = responseBodySize;
-    map['errorDomain'] = errorDomain;
-    map['errorCode'] = errorCode;
-    return map;
+  Map<String, dynamic> toJson() {
+    return {
+      'url': url,
+      'method': method,
+      'requestBody': requestBody,
+      'responseBody': responseBody,
+      'responseCode': status,
+      'requestHeaders':
+          requestHeaders.map((key, value) => MapEntry(key, value.toString())),
+      'responseHeaders':
+          responseHeaders.map((key, value) => MapEntry(key, value.toString())),
+      'requestContentType': requestContentType,
+      'responseContentType': responseContentType,
+      'duration': duration,
+      'startTime': startTime.millisecondsSinceEpoch,
+      'requestBodySize': requestBodySize,
+      'responseBodySize': responseBodySize,
+      'errorDomain': errorDomain,
+      'errorCode': errorCode,
+    };
   }
 }

--- a/lib/src/models/trace.dart
+++ b/lib/src/models/trace.dart
@@ -1,19 +1,14 @@
 import 'package:instabug_flutter/src/modules/apm.dart';
 
 class Trace {
-  String id;
-  String name = '';
-  Map<String, dynamic> attributes;
-  Trace(this.id, this.name, {Map<String, dynamic>? listOfAttributes})
-      : attributes = listOfAttributes ?? <String, dynamic>{};
+  Trace({
+    required this.id,
+    required this.name,
+  });
 
-  Map<String, dynamic> toMap() {
-    final map = <String, dynamic>{};
-    map['id'] = id;
-    map['name'] = name;
-    map['attributes'] = attributes;
-    return map;
-  }
+  final String id;
+  final String name;
+  final Map<String, dynamic> attributes = {};
 
   void setAttribute(String key, String value) {
     APM.setExecutionTraceAttribute(id, key, value);
@@ -22,5 +17,13 @@ class Trace {
 
   void end() {
     APM.endExecutionTrace(id);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'attributes': attributes,
+    };
   }
 }

--- a/lib/src/modules/apm.dart
+++ b/lib/src/modules/apm.dart
@@ -58,7 +58,10 @@ class APM {
       );
     }
 
-    return Trace(traceId, name);
+    return Trace(
+      id: traceId,
+      name: name,
+    );
   }
 
   /// Sets attribute of an execution trace.
@@ -103,7 +106,7 @@ class APM {
 
   static FutureOr<void> networkLogAndroid(NetworkData data) {
     if (IBGBuildInfo.instance.isAndroid) {
-      return _host.networkLogAndroid(data.toMap());
+      return _host.networkLogAndroid(data.toJson());
     }
   }
 }

--- a/lib/src/modules/crash_reporting.dart
+++ b/lib/src/modules/crash_reporting.dart
@@ -60,23 +60,21 @@ class CrashReporting {
     bool handled,
   ) async {
     final trace = Trace.from(stack);
-    final frames = <ExceptionData>[];
-
-    for (var i = 0; i < trace.frames.length; i++) {
-      frames.add(
-        ExceptionData(
-          trace.frames[i].uri.toString(),
-          trace.frames[i].member,
-          trace.frames[i].line,
-          trace.frames[i].column ?? 0,
-        ),
-      );
-    }
+    final frames = trace.frames
+        .map(
+          (frame) => ExceptionData(
+            file: frame.uri.toString(),
+            methodName: frame.member,
+            lineNumber: frame.line,
+            column: frame.column ?? 0,
+          ),
+        )
+        .toList();
 
     final crashData = CrashData(
-      exception.toString(),
-      IBGBuildInfo.instance.operatingSystem,
-      frames,
+      os: IBGBuildInfo.instance.operatingSystem,
+      message: exception.toString(),
+      exception: frames,
     );
 
     return _host.send(jsonEncode(crashData), handled);

--- a/lib/src/modules/network_logger.dart
+++ b/lib/src/modules/network_logger.dart
@@ -17,7 +17,7 @@ class NetworkLogger {
   }
 
   Future<void> networkLog(NetworkData data) async {
-    await _host.networkLog(data.toMap());
+    await _host.networkLog(data.toJson());
     await APM.networkLogAndroid(data);
   }
 }

--- a/test/apm_test.dart
+++ b/test/apm_test.dart
@@ -145,7 +145,7 @@ void main() {
     await APM.networkLogAndroid(data);
 
     verify(
-      mHost.networkLogAndroid(data.toMap()),
+      mHost.networkLogAndroid(data.toJson()),
     ).called(1);
   });
 }

--- a/test/crash_reporting_test.dart
+++ b/test/crash_reporting_test.dart
@@ -46,10 +46,10 @@ void main() {
       final frames = trace.frames
           .map(
             (frame) => ExceptionData(
-              frame.uri.toString(),
-              frame.member,
-              frame.line,
-              frame.column ?? 0,
+              file: frame.uri.toString(),
+              methodName: frame.member,
+              lineNumber: frame.line,
+              column: frame.column ?? 0,
             ),
           )
           .toList();
@@ -57,9 +57,9 @@ void main() {
       when(mBuildInfo.operatingSystem).thenReturn('unit-test');
 
       final data = CrashData(
-        exception.toString(),
-        IBGBuildInfo.instance.operatingSystem,
-        frames,
+        os: IBGBuildInfo.instance.operatingSystem,
+        message: exception.toString(),
+        exception: frames,
       );
 
       await CrashReporting.reportHandledCrash(exception, stack);

--- a/test/network_data_test.dart
+++ b/test/network_data_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   test('[copyWith] should return an exact copy', () async {
     final newData = data.copyWith();
-    expect(newData.toMap(), data.toMap());
+    expect(newData.toJson(), data.toJson());
   });
 
   test('[copyWith] should return an updated copy', () async {
@@ -69,7 +69,7 @@ void main() {
   });
 
   test('[toMap] should return exact data in a map', () async {
-    final map = data.toMap();
+    final map = data.toJson();
 
     expect(map['url'], data.url);
     expect(map['method'], data.method);

--- a/test/network_logger_test.dart
+++ b/test/network_logger_test.dart
@@ -41,11 +41,11 @@ void main() {
     await logger.networkLog(data);
 
     verify(
-      mInstabugHost.networkLog(data.toMap()),
+      mInstabugHost.networkLog(data.toJson()),
     ).called(1);
 
     verifyNever(
-      mApmHost.networkLogAndroid(data.toMap()),
+      mApmHost.networkLogAndroid(data.toJson()),
     );
   });
 
@@ -55,11 +55,11 @@ void main() {
     await logger.networkLog(data);
 
     verify(
-      mInstabugHost.networkLog(data.toMap()),
+      mInstabugHost.networkLog(data.toJson()),
     ).called(1);
 
     verify(
-      mApmHost.networkLogAndroid(data.toMap()),
+      mApmHost.networkLogAndroid(data.toJson()),
     ).called(1);
   });
 }

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -15,7 +15,10 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
 
   final mHost = MockApmHostApi();
-  final trace = Trace("trace", "Execution Trace");
+  final trace = Trace(
+    id: "trace",
+    name: "Execution Trace",
+  );
 
   setUpAll(() {
     APM.$setHostApi(mHost);


### PR DESCRIPTION
## Description of the change

Use the following style across all internal model classes:

```dart
class ModelName {
  // 1. Constructor (const if possible)
  const ModelName({
    required this.firstField,
    required this.secondFiled,
  });
  
  // 2. Fields
  final Type firstField;
  final Type secondField;
  
  // 3. Methods
  void firstMethod() {
  }
  
  // 4. JSON encoding (used with `jsonEncode`)
  Map<String, dynamic> toJson() {
    return {
      'firstField': firstField,
      'secondFiled': secondFiled,
    };
  }
}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
