### PR TITLE
[MOB-10572] Add new APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Adds BugReporting.setDisclaimerText API
+* Adds BugReporting.setCommentMinimumCharacterCount API
+* Deprecates Instabug.enableAndroid and Instabug.disableAndroid APIs in favour of a new API Instabug.setEnabled, which works on both platforms
 * Fixes main thread violation on Android
 * Fixes an issue with request and response headers parameters type causing network requests not getting logged on iOS
 * Uses pigeon for internal communication between Flutter and the host platform

--- a/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
@@ -154,4 +154,16 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
     public void setDisclaimerText(@NonNull String text) {
         BugReporting.setDisclaimerText(text);
     }
+
+    @Override
+    public void setCommentMinimumCharacterCount(@NonNull Long limit, @Nullable List<String> reportTypes) {
+        int[] reportTypesArray = reportTypes == null ? new int[0] : new int[reportTypes.size()];
+        if(reportTypes != null){
+        for (int i = 0; i < reportTypes.size(); i++) {
+            String key = reportTypes.get(i);
+            reportTypesArray[i] = ArgsRegistry.getDeserializedValue(key);
+        }
+    }
+        BugReporting.setCommentMinimumCharacterCount(limit.intValue(), reportTypesArray);
+    }
 }

--- a/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
@@ -149,4 +149,9 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
             }
         });
     }
+
+    @Override
+    public void setDisclaimerText(@NonNull String text) {
+        BugReporting.setDisclaimerText(text);
+    }
 }

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -73,6 +73,18 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         }
     }
 
+    @Override
+    public void setEnabled(@NonNull Boolean isEnabled) {
+        try {
+            if(isEnabled)
+                Instabug.enable();
+            else
+                Instabug.disable();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     public void start(@NonNull String token, @NonNull List<String> invocationEvents) {
         setCurrentPlatform();
 

--- a/ios/Classes/Modules/BugReportingApi.m
+++ b/ios/Classes/Modules/BugReportingApi.m
@@ -146,4 +146,8 @@ extern void InitBugReportingApi(id<FlutterBinaryMessenger> messenger) {
     };
 }
 
+- (void)setDisclaimerTextText:(NSString *)text error:(FlutterError *_Nullable *_Nonnull)error {
+    [IBGBugReporting setDisclaimerText:text];
+}
+
 @end

--- a/ios/Classes/Modules/BugReportingApi.m
+++ b/ios/Classes/Modules/BugReportingApi.m
@@ -150,4 +150,19 @@ extern void InitBugReportingApi(id<FlutterBinaryMessenger> messenger) {
     [IBGBugReporting setDisclaimerText:text];
 }
 
+- (void)setCommentMinimumCharacterCountLimit:(NSNumber *)limit reportTypes:(nullable NSArray<NSString *> *)reportTypes error:(FlutterError *_Nullable *_Nonnull)error {
+    IBGBugReportingReportType resolvedTypes = 0;
+
+    if (![reportTypes count]) {
+        resolvedTypes = (ArgsRegistry.reportTypes[@"ReportType.bug"]).integerValue | (ArgsRegistry.reportTypes[@"ReportType.feedback"]).integerValue | (ArgsRegistry.reportTypes[@"ReportType.question"]).integerValue;
+    }
+    else {
+        for (NSString *reportType in reportTypes) {
+            resolvedTypes |= (ArgsRegistry.reportTypes[reportType]).integerValue;
+        }
+    }
+    
+    [IBGBugReporting setCommentMinimumCharacterCountForReportTypes:resolvedTypes withLimit:limit.intValue];
+}
+
 @end

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -13,6 +13,10 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
 
 @implementation InstabugApi
 
+- (void)setEnabledIsEnabled:(NSNumber *)isEnabled error:(FlutterError *_Nullable *_Nonnull)error {
+    Instabug.enabled = [isEnabled boolValue];
+}
+
 - (void)startToken:(NSString *)token invocationEvents:(NSArray<NSString *> *)invocationEvents error:(FlutterError *_Nullable *_Nonnull)error {
     SEL setPrivateApiSEL = NSSelectorFromString(@"setCurrentPlatform:");
     if ([[Instabug class] respondsToSelector:setPrivateApiSEL]) {

--- a/lib/src/modules/bug_reporting.dart
+++ b/lib/src/modules/bug_reporting.dart
@@ -235,6 +235,11 @@ class BugReporting implements BugReportingFlutterApi {
     return _host.setDisclaimerText(text);
   }
 
+  /// Sets a minimum number of characters as a requirement for
+  /// the comments field in the different report types.
+  /// [limit] int number of characters
+  /// [reportTypes] Optional list of ReportType. If it's not passed,
+  /// the limit will apply to all report types.
   static Future<void> setCommentMinimumCharacterCount(
     int limit, [
     List<ReportType>? reportTypes,

--- a/lib/src/modules/bug_reporting.dart
+++ b/lib/src/modules/bug_reporting.dart
@@ -227,4 +227,11 @@ class BugReporting implements BugReportingFlutterApi {
       return _host.setShakingThresholdForAndroid(threshold);
     }
   }
+
+  /// Adds a disclaimer text within the bug reporting form,
+  /// which can include hyperlinked text.
+  /// [text] String text
+  static Future<void> setDisclaimerText(String text) async {
+    return _host.setDisclaimerText(text);
+  }
 }

--- a/lib/src/modules/bug_reporting.dart
+++ b/lib/src/modules/bug_reporting.dart
@@ -234,4 +234,14 @@ class BugReporting implements BugReportingFlutterApi {
   static Future<void> setDisclaimerText(String text) async {
     return _host.setDisclaimerText(text);
   }
+
+  static Future<void> setCommentMinimumCharacterCount(
+    int limit, [
+    List<ReportType>? reportTypes,
+  ]) async {
+    return _host.setCommentMinimumCharacterCount(
+      limit,
+      reportTypes?.mapToString(),
+    );
+  }
 }

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -345,24 +345,22 @@ class Instabug {
     return _host.setReproStepsMode(reproStepsMode.toString());
   }
 
+  /// Android Only
+  /// Enables all Instabug functionality
   @Deprecated(
     "Use [Instabug.setEnabled(true)] instead. This will work on both Android and iOS. ",
   )
-
-  /// Android Only
-  /// Enables all Instabug functionality
   static Future<void> enableAndroid() async {
     if (IBGBuildInfo.I.isAndroid) {
       return _host.enableAndroid();
     }
   }
 
+  /// Android Only
+  /// Disables all Instabug functionality
   @Deprecated(
     "Use [Instabug.setEnabled(false)] instead. This will work on both Android and iOS. ",
   )
-
-  /// Android Only
-  /// Disables all Instabug functionality
   static Future<void> disableAndroid() async {
     if (IBGBuildInfo.I.isAndroid) {
       return _host.disableAndroid();

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -129,6 +129,12 @@ class Instabug {
     Surveys.init();
   }
 
+  /// Enables or disables Instabug functionality.
+  /// [boolean] isEnabled
+  static Future<void> setEnabled(bool isEnabled) async {
+    return _host.setEnabled(isEnabled);
+  }
+
   /// Starts the SDK.
   /// This is the main SDK method that does all the magic. This is the only
   /// method that SHOULD be called.

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -345,6 +345,10 @@ class Instabug {
     return _host.setReproStepsMode(reproStepsMode.toString());
   }
 
+  @Deprecated(
+    "Use [Instabug.setEnabled(true)] instead. This will work on both Android and iOS. ",
+  )
+
   /// Android Only
   /// Enables all Instabug functionality
   static Future<void> enableAndroid() async {
@@ -352,6 +356,10 @@ class Instabug {
       return _host.enableAndroid();
     }
   }
+
+  @Deprecated(
+    "Use [Instabug.setEnabled(false)] instead. This will work on both Android and iOS. ",
+  )
 
   /// Android Only
   /// Disables all Instabug functionality

--- a/pigeons/bug_reporting.api.dart
+++ b/pigeons/bug_reporting.api.dart
@@ -28,4 +28,8 @@ abstract class BugReportingHostApi {
   void bindOnInvokeCallback();
   void bindOnDismissCallback();
   void setDisclaimerText(String text);
+  void setCommentMinimumCharacterCount(
+    int limit,
+    List<String>? reportTypes,
+  );
 }

--- a/pigeons/bug_reporting.api.dart
+++ b/pigeons/bug_reporting.api.dart
@@ -27,4 +27,5 @@ abstract class BugReportingHostApi {
   );
   void bindOnInvokeCallback();
   void bindOnDismissCallback();
+  void setDisclaimerText(String text);
 }

--- a/pigeons/instabug.api.dart
+++ b/pigeons/instabug.api.dart
@@ -2,6 +2,7 @@ import 'package:pigeon/pigeon.dart';
 
 @HostApi()
 abstract class InstabugHostApi {
+  void setEnabled(bool isEnabled);
   void start(String token, List<String> invocationEvents);
 
   void show();

--- a/test/bug_reporting_test.dart
+++ b/test/bug_reporting_test.dart
@@ -178,4 +178,14 @@ void main() {
       mHost.bindOnDismissCallback(),
     ).called(1);
   });
+
+  test('[setDisclaimerText] should call host method', () async {
+    const text = 'This is a disclaimer text!';
+
+    await BugReporting.setDisclaimerText(text);
+
+    verify(
+      mHost.setDisclaimerText(text),
+    ).called(1);
+  });
 }

--- a/test/bug_reporting_test.dart
+++ b/test/bug_reporting_test.dart
@@ -188,4 +188,15 @@ void main() {
       mHost.setDisclaimerText(text),
     ).called(1);
   });
+
+  test('[setCommentMinimumCharacterCount] should call host method', () async {
+    const count = 20;
+    const reportTypes = [ReportType.bug];
+
+    await BugReporting.setCommentMinimumCharacterCount(count, reportTypes);
+
+    verify(
+      mHost.setCommentMinimumCharacterCount(count, reportTypes.mapToString()),
+    ).called(1);
+  });
 }

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -27,6 +27,16 @@ void main() {
     IBGBuildInfo.setInstance(mBuildInfo);
   });
 
+  test('[setEnabled] should call host method', () async {
+    const enabled = true;
+
+    await Instabug.setEnabled(enabled);
+
+    verify(
+      mHost.setEnabled(enabled),
+    ).called(1);
+  });
+
   test('[start] should call host method', () async {
     const token = "068ba9a8c3615035e163dc5f829c73be";
     const events = [InvocationEvent.shake, InvocationEvent.screenshot];

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -344,6 +344,7 @@ void main() {
   test('[enableAndroid] should call host method', () async {
     when(mBuildInfo.isAndroid).thenReturn(true);
 
+    // ignore: deprecated_member_use_from_same_package
     await Instabug.enableAndroid();
 
     verify(
@@ -354,6 +355,7 @@ void main() {
   test('[disableAndroid] should call host method', () async {
     when(mBuildInfo.isAndroid).thenReturn(true);
 
+    // ignore: deprecated_member_use_from_same_package
     await Instabug.disableAndroid();
 
     verify(


### PR DESCRIPTION
## Description of the change

1. Adds `BugReporting.setDisclaimerText` API
2. Adds `BugReporting.setCommentMinimumCharacterCount` API
3. Deprecates `Instabug.enableAndroid` and `Instabug.disableAndroid` APIs in favour of a new API `Instabug.setEnabled`, which works on both platforms
4. Adds unit tests for the new APIs

**Usage Examples:** 🚀 

1. 

```
BugReporting.setDisclaimerText(
      "Instabug can help developers produce more quality code. [Learn more](https://www.instabug.com)"); 
```
2. 
`BugReporting.setCommentMinimumCharacterCount(20);`

Another usage:
```
BugReporting.setCommentMinimumCharacterCount(
      20, [ReportType.bug, ReportType.feedback]);
```
3. `Instabug.setEnabled(true);` OR `Instabug.setEnabled(false);`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
