### PR TITLE
[MOB-10950] Make `ArgsRegistry` Type-safe on Android

### DIFF
--- a/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
@@ -59,10 +59,8 @@ public class ApmApi implements ApmPigeon.ApmHostApi {
     @Override
     public void setLogLevel(@NonNull String level) {
         try {
-            if (ArgsRegistry.getDeserializedValue(level) == null) {
-                return;
-            }
-            APM.setLogLevel((int) ArgsRegistry.getRawValue(level));
+            final int resolvedLevel = ArgsRegistry.logLevels.get(level);
+            APM.setLogLevel(resolvedLevel);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
@@ -1,5 +1,7 @@
 package com.instabug.flutter.modules;
 
+import android.annotation.SuppressLint;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -40,13 +42,14 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
         }
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void show(@NonNull String reportType, @Nullable List<String> invocationOptions) {
         int[] options = new int[invocationOptions.size()];
         for (int i = 0; i < invocationOptions.size(); i++) {
-            options[i] = ArgsRegistry.getDeserializedValue(invocationOptions.get(i));
+            options[i] = ArgsRegistry.invocationOptions.get(invocationOptions.get(i));
         }
-        int reportTypeInt = ArgsRegistry.getDeserializedValue(reportType);
+        int reportTypeInt = ArgsRegistry.reportTypes.get(reportType);
         BugReporting.show(reportTypeInt, options);
     }
 
@@ -56,19 +59,20 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
 
         for (int i = 0; i < events.size(); i++) {
             String key = events.get(i);
-            invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key);
+            invocationEventsArray[i] = ArgsRegistry.invocationEvents.get(key);
         }
 
         BugReporting.setInvocationEvents(invocationEventsArray);
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void setReportTypes(@NonNull List<String> types) {
         int[] reportTypesArray = new int[types.size()];
 
         for (int i = 0; i < types.size(); i++) {
             String key = types.get(i);
-            reportTypesArray[i] = ArgsRegistry.getDeserializedValue(key);
+            reportTypesArray[i] = ArgsRegistry.reportTypes.get(key);
         }
 
         BugReporting.setReportTypes(reportTypesArray);
@@ -76,29 +80,30 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
 
     @Override
     public void setExtendedBugReportMode(@NonNull String mode) {
-        final ExtendedBugReport.State resolvedMode = ArgsRegistry.getDeserializedValue(mode);
+        final ExtendedBugReport.State resolvedMode = ArgsRegistry.extendedBugReportStates.get(mode);
         BugReporting.setExtendedBugReportState(resolvedMode);
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void setInvocationOptions(@NonNull List<String> options) {
         int[] resolvedOptions = new int[options.size()];
         for (int i = 0; i < options.size(); i++) {
-            resolvedOptions[i] = ArgsRegistry.getDeserializedValue(options.get(i));
+            resolvedOptions[i] = ArgsRegistry.invocationOptions.get(options.get(i));
         }
         BugReporting.setOptions(resolvedOptions);
     }
 
     @Override
     public void setFloatingButtonEdge(@NonNull String edge, @NonNull Long offset) {
-        final InstabugFloatingButtonEdge resolvedEdge = ArgsRegistry.getDeserializedValue(edge);
+        final InstabugFloatingButtonEdge resolvedEdge = ArgsRegistry.floatingButtonEdges.get(edge);
         BugReporting.setFloatingButtonEdge(resolvedEdge);
         BugReporting.setFloatingButtonOffset(offset.intValue());
     }
 
     @Override
     public void setVideoRecordingFloatingButtonPosition(@NonNull String position) {
-        final InstabugVideoRecordingButtonPosition resolvedPosition = ArgsRegistry.getDeserializedValue(position);
+        final InstabugVideoRecordingButtonPosition resolvedPosition = ArgsRegistry.recordButtonPositions.get(position);
         BugReporting.setVideoRecordingFloatingButtonPosition(resolvedPosition);
     }
 
@@ -155,13 +160,14 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
         BugReporting.setDisclaimerText(text);
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void setCommentMinimumCharacterCount(@NonNull Long limit, @Nullable List<String> reportTypes) {
         int[] reportTypesArray = reportTypes == null ? new int[0] : new int[reportTypes.size()];
         if(reportTypes != null){
         for (int i = 0; i < reportTypes.size(); i++) {
             String key = reportTypes.get(i);
-            reportTypesArray[i] = ArgsRegistry.getDeserializedValue(key);
+            reportTypesArray[i] = ArgsRegistry.reportTypes.get(key);
         }
     }
         BugReporting.setCommentMinimumCharacterCount(limit.intValue(), reportTypesArray);

--- a/android/src/main/java/com/instabug/flutter/modules/FeatureRequestsApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/FeatureRequestsApi.java
@@ -1,5 +1,7 @@
 package com.instabug.flutter.modules;
 
+import android.annotation.SuppressLint;
+
 import androidx.annotation.NonNull;
 
 import com.instabug.featuresrequest.FeatureRequests;
@@ -22,11 +24,12 @@ public class FeatureRequestsApi implements FeatureRequestsPigeon.FeatureRequests
         FeatureRequests.show();
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void setEmailFieldRequired(@NonNull Boolean isRequired, @NonNull List<String> actionTypes) {
         int[] actions = new int[actionTypes.size()];
         for (int i = 0; i < actionTypes.size(); i++) {
-            actions[i] = ArgsRegistry.getDeserializedValue(actionTypes.get(i));
+            actions[i] = ArgsRegistry.actionTypes.get(actionTypes.get(i));
         }
 
         FeatureRequests.setEmailFieldRequired(isRequired, actions);

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -12,7 +12,6 @@ import androidx.annotation.Nullable;
 
 import com.instabug.flutter.util.ArgsRegistry;
 import com.instabug.flutter.generated.InstabugPigeon;
-import com.instabug.flutter.util.ArgsRegistry;
 import com.instabug.flutter.util.Reflection;
 import com.instabug.flutter.util.ThreadManager;
 import com.instabug.library.Feature;
@@ -20,9 +19,11 @@ import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder;
 import com.instabug.library.Platform;
+import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.model.NetworkLog;
 import com.instabug.library.ui.onboarding.WelcomeMessage;
+import com.instabug.library.visualusersteps.State;
 
 import org.json.JSONObject;
 
@@ -87,7 +88,7 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[invocationEvents.size()];
         for (int i = 0; i < invocationEvents.size(); i++) {
             String key = invocationEvents.get(i);
-            invocationEventsArray[i] = ArgsRegistry.getDeserializedValue(key);
+            invocationEventsArray[i] = ArgsRegistry.invocationEvents.get(key);
         }
 
         final Application application = (Application) context;
@@ -104,8 +105,8 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
     @Override
     public void showWelcomeMessageWithMode(@NonNull String mode) {
-        WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(mode);
-        Instabug.showWelcomeMessage(resolvedWelcomeMessageMode);
+        WelcomeMessage.State resolvedMode = ArgsRegistry.welcomeMessageStates.get(mode);
+        Instabug.showWelcomeMessage(resolvedMode);
     }
 
     @Override
@@ -130,22 +131,20 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
     @Override
     public void setLocale(@NonNull String locale) {
-        Locale resolvedLocale = ArgsRegistry.getDeserializedValue(locale);
-        Instabug.setLocale(resolvedLocale);
+        final InstabugLocale resolvedLocale = ArgsRegistry.locales.get(locale);
+        Instabug.setLocale(new Locale(resolvedLocale.getCode(), resolvedLocale.getCountry()));
     }
 
     @Override
     public void setColorTheme(@NonNull String theme) {
-        InstabugColorTheme resolvedTheme = ArgsRegistry.getDeserializedValue(theme);
-        if (resolvedTheme != null) {
-            Instabug.setColorTheme(resolvedTheme);
-        }
+        InstabugColorTheme resolvedTheme = ArgsRegistry.colorThemes.get(theme);
+        Instabug.setColorTheme(resolvedTheme);
     }
 
     @Override
     public void setWelcomeMessageMode(@NonNull String mode) {
-        WelcomeMessage.State resolvedWelcomeMessageMode = ArgsRegistry.getDeserializedValue(mode);
-        Instabug.setWelcomeMessageState(resolvedWelcomeMessageMode);
+        WelcomeMessage.State resolvedMode = ArgsRegistry.welcomeMessageStates.get(mode);
+        Instabug.setWelcomeMessageState(resolvedMode);
     }
 
     @Override
@@ -164,7 +163,7 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
     @Override
     public void setValueForStringWithKey(@NonNull String value, @NonNull String key) {
-        InstabugCustomTextPlaceHolder.Key resolvedKey = ArgsRegistry.getDeserializedValue(key);
+        InstabugCustomTextPlaceHolder.Key resolvedKey = ArgsRegistry.placeholders.get(key);
         placeHolder.set(resolvedKey, value);
         Instabug.setCustomTextPlaceHolders(placeHolder);
     }
@@ -254,7 +253,8 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
     @Override
     public void setReproStepsMode(@NonNull String mode) {
         try {
-            Instabug.setReproStepsState(ArgsRegistry.getDeserializedValue(mode));
+            final State resolvedMode = ArgsRegistry.reproStates.get(mode);
+            Instabug.setReproStepsState(resolvedMode);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
@@ -1,262 +1,197 @@
 package com.instabug.flutter.util;
 
-import static com.instabug.library.internal.module.InstabugLocale.ARABIC;
-import static com.instabug.library.internal.module.InstabugLocale.AZERBAIJANI;
-import static com.instabug.library.internal.module.InstabugLocale.CZECH;
-import static com.instabug.library.internal.module.InstabugLocale.DANISH;
-import static com.instabug.library.internal.module.InstabugLocale.ENGLISH;
-import static com.instabug.library.internal.module.InstabugLocale.FRENCH;
-import static com.instabug.library.internal.module.InstabugLocale.GERMAN;
-import static com.instabug.library.internal.module.InstabugLocale.INDONESIAN;
-import static com.instabug.library.internal.module.InstabugLocale.ITALIAN;
-import static com.instabug.library.internal.module.InstabugLocale.JAPANESE;
-import static com.instabug.library.internal.module.InstabugLocale.KOREAN;
-import static com.instabug.library.internal.module.InstabugLocale.NETHERLANDS;
-import static com.instabug.library.internal.module.InstabugLocale.NORWEGIAN;
-import static com.instabug.library.internal.module.InstabugLocale.POLISH;
-import static com.instabug.library.internal.module.InstabugLocale.PORTUGUESE_BRAZIL;
-import static com.instabug.library.internal.module.InstabugLocale.PORTUGUESE_PORTUGAL;
-import static com.instabug.library.internal.module.InstabugLocale.RUSSIAN;
-import static com.instabug.library.internal.module.InstabugLocale.SIMPLIFIED_CHINESE;
-import static com.instabug.library.internal.module.InstabugLocale.SLOVAK;
-import static com.instabug.library.internal.module.InstabugLocale.SPANISH;
-import static com.instabug.library.internal.module.InstabugLocale.SWEDISH;
-import static com.instabug.library.internal.module.InstabugLocale.TRADITIONAL_CHINESE;
-import static com.instabug.library.internal.module.InstabugLocale.TURKISH;
-import static com.instabug.library.internal.module.InstabugLocale.ROMANIAN;
-import static com.instabug.library.invocation.InstabugInvocationEvent.FLOATING_BUTTON;
-import static com.instabug.library.invocation.InstabugInvocationEvent.NONE;
-import static com.instabug.library.invocation.InstabugInvocationEvent.SCREENSHOT;
-import static com.instabug.library.invocation.InstabugInvocationEvent.SHAKE;
-import static com.instabug.library.invocation.InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT;
-import static com.instabug.library.ui.onboarding.WelcomeMessage.State.BETA;
-import static com.instabug.library.ui.onboarding.WelcomeMessage.State.DISABLED;
-import static com.instabug.library.ui.onboarding.WelcomeMessage.State.LIVE;
+import androidx.annotation.NonNull;
 
 import com.instabug.apm.model.LogLevel;
 import com.instabug.bug.BugReporting;
 import com.instabug.bug.invocation.Option;
 import com.instabug.featuresrequest.ActionType;
 import com.instabug.library.InstabugColorTheme;
-import com.instabug.library.InstabugCustomTextPlaceHolder;
+import com.instabug.library.InstabugCustomTextPlaceHolder.Key;
+import com.instabug.library.OnSdkDismissCallback.DismissType;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
+import com.instabug.library.internal.module.InstabugLocale;
+import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.invocation.util.InstabugFloatingButtonEdge;
 import com.instabug.library.invocation.util.InstabugVideoRecordingButtonPosition;
+import com.instabug.library.ui.onboarding.WelcomeMessage;
 import com.instabug.library.visualusersteps.State;
 
 import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+import java.util.Objects;
 
-@SuppressWarnings({"SameParameterValue", "unchecked"})
-final public class ArgsRegistry {
+public final class ArgsRegistry {
 
-    public static final Map<String, Object> ARGS = new HashMap<>();
-
-    static {
-        registerInstabugInvocationEventsArgs(ARGS);
-        registerWelcomeMessageArgs(ARGS);
-        registerColorThemeArgs(ARGS);
-        registerLocaleArgs(ARGS);
-        registerInvocationOptionsArgs(ARGS);
-        registerInstabugFloatingButtonEdgeArgs(ARGS);
-        registerInstabugVideoRecordingButtonPositionArgs(ARGS);
-        registerCustomTextPlaceHolderKeysArgs(ARGS);
-        registerInstabugReportTypesArgs(ARGS);
-        registerInstabugExtendedBugReportModeArgs(ARGS);
-        registerInstabugActionTypesArgs(ARGS);
-        registerReproStepsModeArgs(ARGS);
-        registerLogLevelArgs(ARGS);
-    }
-
-    /**
-     * This acts as a safe get() method.
-     * It returns the queried value after deserialization if AND ONLY IF it passed the following assertions:
-     * - {@code key} is not null
-     * - {@code key} does exist in the registry
-     * - The value assigned to the {@code key} is not null
-     *
-     * @param key the key whose associated value is to be returned
-     * @return the value deserialized if all the assertions were successful, null otherwise
-     */
-    public static <T> T getDeserializedValue(String key) {
-        if (key != null && ARGS.containsKey(key)) {
-            Object constant = ARGS.get(key);
-            if (constant != null) {
-                return (T) constant;
-            }
+    public static class ArgsMap<T> extends HashMap<String, T> {
+        @NonNull
+        @Override
+        public T get(Object key) {
+            return Objects.requireNonNull(super.get(key));
         }
-        return null;
     }
 
-    /**
-     * This acts as a safe get() method.
-     * It returns the queried raw value if AND ONLY IF it passed the following assertions:
-     * - {@code key} is not null
-     * - {@code key} does exist in the registry
-     * (i.e. Object value = getRawValue("key")
-     *
-     * @param key the key whose associated value is to be returned
-     * @return the value  if all the assertions were successful, null otherwise
-     */
-    public static Object getRawValue(String key) {
-        if (key != null) {
-            return ARGS.get(key);
-        }
-        return null;
-    }
+    public static final ArgsMap<Integer> logLevels = new ArgsMap<Integer>() {{
+        put("LogLevel.none", LogLevel.NONE);
+        put("LogLevel.error", LogLevel.ERROR);
+        put("LogLevel.warning", LogLevel.WARNING);
+        put("LogLevel.info", LogLevel.INFO);
+        put("LogLevel.debug", LogLevel.DEBUG);
+        put("LogLevel.verbose", LogLevel.VERBOSE);
+    }};
 
-    public static void registerInstabugInvocationEventsArgs(Map<String, Object> args) {
-        args.put("InvocationEvent.twoFingersSwipeLeft", TWO_FINGER_SWIPE_LEFT);
-        args.put("InvocationEvent.floatingButton", FLOATING_BUTTON);
-        args.put("InvocationEvent.screenshot", SCREENSHOT);
-        args.put("InvocationEvent.shake", SHAKE);
-        args.put("InvocationEvent.none", NONE);
-    }
+    public static ArgsMap<InstabugInvocationEvent> invocationEvents = new ArgsMap<InstabugInvocationEvent>() {{
+        put("InvocationEvent.none", InstabugInvocationEvent.NONE);
+        put("InvocationEvent.shake", InstabugInvocationEvent.SHAKE);
+        put("InvocationEvent.floatingButton", InstabugInvocationEvent.FLOATING_BUTTON);
+        put("InvocationEvent.screenshot", InstabugInvocationEvent.SCREENSHOT);
+        put("InvocationEvent.twoFingersSwipeLeft", InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT);
+    }};
 
-    public static void registerWelcomeMessageArgs(Map<String, Object> args) {
-        args.put("WelcomeMessageMode.disabled", DISABLED);
-        args.put("WelcomeMessageMode.live", LIVE);
-        args.put("WelcomeMessageMode.beta", BETA);
-    }
+    public static final ArgsMap<Integer> invocationOptions = new ArgsMap<Integer>() {{
+        put("InvocationOption.emailFieldHidden", Option.EMAIL_FIELD_HIDDEN);
+        put("InvocationOption.emailFieldOptional", Option.EMAIL_FIELD_OPTIONAL);
+        put("InvocationOption.commentFieldRequired", Option.COMMENT_FIELD_REQUIRED);
+        put("InvocationOption.disablePostSendingDialog", Option.DISABLE_POST_SENDING_DIALOG);
+    }};
 
-    public static void registerColorThemeArgs(Map<String, Object> args) {
-        args.put("ColorTheme.light", InstabugColorTheme.InstabugColorThemeLight);
-        args.put("ColorTheme.dark", InstabugColorTheme.InstabugColorThemeDark);
-    }
+    public static final ArgsMap<InstabugColorTheme> colorThemes = new ArgsMap<InstabugColorTheme>() {{
+        put("ColorTheme.light", InstabugColorTheme.InstabugColorThemeLight);
+        put("ColorTheme.dark", InstabugColorTheme.InstabugColorThemeDark);
+    }};
 
-    public static void registerInstabugFloatingButtonEdgeArgs(Map<String, Object> args) {
-        args.put("FloatingButtonEdge.left", InstabugFloatingButtonEdge.LEFT);
-        args.put("FloatingButtonEdge.right", InstabugFloatingButtonEdge.RIGHT);
-    }
+    public static final ArgsMap<InstabugFloatingButtonEdge> floatingButtonEdges = new ArgsMap<InstabugFloatingButtonEdge>() {{
+        put("FloatingButtonEdge.left", InstabugFloatingButtonEdge.LEFT);
+        put("FloatingButtonEdge.right", InstabugFloatingButtonEdge.RIGHT);
+    }};
 
-    public static void registerInstabugVideoRecordingButtonPositionArgs(Map<String, Object> args) {
-        args.put("Position.topRight", InstabugVideoRecordingButtonPosition.TOP_RIGHT);
-        args.put("Position.topLeft", InstabugVideoRecordingButtonPosition.TOP_LEFT);
-        args.put("Position.bottomRight", InstabugVideoRecordingButtonPosition.BOTTOM_RIGHT);
-        args.put("Position.bottomLeft", InstabugVideoRecordingButtonPosition.BOTTOM_LEFT);
-    }
+    public static ArgsMap<InstabugVideoRecordingButtonPosition> recordButtonPositions = new ArgsMap<InstabugVideoRecordingButtonPosition>() {{
+        put("Position.topLeft", InstabugVideoRecordingButtonPosition.TOP_LEFT);
+        put("Position.topRight", InstabugVideoRecordingButtonPosition.TOP_RIGHT);
+        put("Position.bottomLeft", InstabugVideoRecordingButtonPosition.BOTTOM_LEFT);
+        put("Position.bottomRight", InstabugVideoRecordingButtonPosition.BOTTOM_RIGHT);
+    }};
 
-    public static void registerInvocationOptionsArgs(Map<String, Object> args) {
-        args.put("InvocationOption.commentFieldRequired", Option.COMMENT_FIELD_REQUIRED);
-        args.put("InvocationOption.disablePostSendingDialog", Option.DISABLE_POST_SENDING_DIALOG);
-        args.put("InvocationOption.emailFieldHidden", Option.EMAIL_FIELD_HIDDEN);
-        args.put("InvocationOption.emailFieldOptional", Option.EMAIL_FIELD_OPTIONAL);
-    }
+    public static ArgsMap<WelcomeMessage.State> welcomeMessageStates = new ArgsMap<WelcomeMessage.State>() {{
+        put("WelcomeMessageMode.live", WelcomeMessage.State.LIVE);
+        put("WelcomeMessageMode.beta", WelcomeMessage.State.BETA);
+        put("WelcomeMessageMode.disabled", WelcomeMessage.State.DISABLED);
+    }};
 
-    public static void registerLocaleArgs(Map<String, Object> args) {
-        args.put("IBGLocale.chineseTraditional", new Locale(TRADITIONAL_CHINESE.getCode(), TRADITIONAL_CHINESE.getCountry()));
-        args.put("IBGLocale.portuguesePortugal", new Locale(PORTUGUESE_PORTUGAL.getCode(), PORTUGUESE_PORTUGAL.getCountry()));
-        args.put("IBGLocale.chineseSimplified", new Locale(SIMPLIFIED_CHINESE.getCode(), SIMPLIFIED_CHINESE.getCountry()));
-        args.put("IBGLocale.portugueseBrazil", new Locale(PORTUGUESE_BRAZIL.getCode(), PORTUGUESE_BRAZIL.getCountry()));
-        args.put("IBGLocale.indonesian", new Locale(INDONESIAN.getCode(), INDONESIAN.getCountry()));
-        args.put("IBGLocale.dutch", new Locale(NETHERLANDS.getCode(), NETHERLANDS.getCountry()));
-        args.put("IBGLocale.norwegian", new Locale(NORWEGIAN.getCode(), NORWEGIAN.getCountry()));
-        args.put("IBGLocale.japanese", new Locale(JAPANESE.getCode(), JAPANESE.getCountry()));
-        args.put("IBGLocale.english", new Locale(ENGLISH.getCode(), ENGLISH.getCountry()));
-        args.put("IBGLocale.italian", new Locale(ITALIAN.getCode(), ITALIAN.getCountry()));
-        args.put("IBGLocale.russian", new Locale(RUSSIAN.getCode(), RUSSIAN.getCountry()));
-        args.put("IBGLocale.spanish", new Locale(SPANISH.getCode(), SPANISH.getCountry()));
-        args.put("IBGLocale.swedish", new Locale(SWEDISH.getCode(), SWEDISH.getCountry()));
-        args.put("IBGLocale.turkish", new Locale(TURKISH.getCode(), TURKISH.getCountry()));
-        args.put("IBGLocale.arabic", new Locale(ARABIC.getCode(), ARABIC.getCountry()));
-        args.put("IBGLocale.azerbaijani", new Locale(AZERBAIJANI.getCode(), AZERBAIJANI.getCountry()));
-        args.put("IBGLocale.danish", new Locale(DANISH.getCode(), DANISH.getCountry()));
-        args.put("IBGLocale.french", new Locale(FRENCH.getCode(), FRENCH.getCountry()));
-        args.put("IBGLocale.german", new Locale(GERMAN.getCode(), GERMAN.getCountry()));
-        args.put("IBGLocale.korean", new Locale(KOREAN.getCode(), KOREAN.getCountry()));
-        args.put("IBGLocale.polish", new Locale(POLISH.getCode(), POLISH.getCountry()));
-        args.put("IBGLocale.slovak", new Locale(SLOVAK.getCode(), SLOVAK.getCountry()));
-        args.put("IBGLocale.czech", new Locale(CZECH.getCode(), CZECH.getCountry()));
-        args.put("IBGLocale.romanian", new Locale(ROMANIAN.getCode(), ROMANIAN.getCountry()));
-    }
+    public static final ArgsMap<Integer> reportTypes = new ArgsMap<Integer>() {{
+        put("ReportType.bug", BugReporting.ReportType.BUG);
+        put("ReportType.feedback", BugReporting.ReportType.FEEDBACK);
+        put("ReportType.question", BugReporting.ReportType.QUESTION);
+    }};
 
-    public static void registerCustomTextPlaceHolderKeysArgs(Map<String, Object> args) {
-        args.put("CustomTextPlaceHolderKey.shakeHint", InstabugCustomTextPlaceHolder.Key.SHAKE_HINT);
-        args.put("CustomTextPlaceHolderKey.swipeHint", InstabugCustomTextPlaceHolder.Key.SWIPE_HINT);
-        args.put("CustomTextPlaceHolderKey.invalidEmailMessage", InstabugCustomTextPlaceHolder.Key.INVALID_EMAIL_MESSAGE);
-        args.put("CustomTextPlaceHolderKey.invalidCommentMessage", InstabugCustomTextPlaceHolder.Key.INVALID_COMMENT_MESSAGE);
-        args.put("CustomTextPlaceHolderKey.invocationHeader", InstabugCustomTextPlaceHolder.Key.INVOCATION_HEADER);
-        args.put("CustomTextPlaceHolderKey.reportQuestion", InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION);
-        args.put("CustomTextPlaceHolderKey.reportBug", InstabugCustomTextPlaceHolder.Key.REPORT_BUG);
-        args.put("CustomTextPlaceHolderKey.reportFeedback", InstabugCustomTextPlaceHolder.Key.REPORT_FEEDBACK);
-        args.put("CustomTextPlaceHolderKey.emailFieldHint", InstabugCustomTextPlaceHolder.Key.EMAIL_FIELD_HINT);
-        args.put("CustomTextPlaceHolderKey.commentFieldHintForBugReport", InstabugCustomTextPlaceHolder.Key.COMMENT_FIELD_HINT_FOR_BUG_REPORT);
-        args.put("CustomTextPlaceHolderKey.commentFieldHintForFeedback", InstabugCustomTextPlaceHolder.Key.COMMENT_FIELD_HINT_FOR_FEEDBACK);
-        args.put("CustomTextPlaceHolderKey.commentFieldHintForQuestion", InstabugCustomTextPlaceHolder.Key.COMMENT_FIELD_HINT_FOR_QUESTION);
-        args.put("CustomTextPlaceHolderKey.addVoiceMessage", InstabugCustomTextPlaceHolder.Key.ADD_VOICE_MESSAGE);
-        args.put("CustomTextPlaceHolderKey.addImageFromGallery", InstabugCustomTextPlaceHolder.Key.ADD_IMAGE_FROM_GALLERY);
-        args.put("CustomTextPlaceHolderKey.addExtraScreenshot", InstabugCustomTextPlaceHolder.Key.ADD_EXTRA_SCREENSHOT);
-        args.put("CustomTextPlaceHolderKey.conversationsListTitle", InstabugCustomTextPlaceHolder.Key.CONVERSATIONS_LIST_TITLE);
-        args.put("CustomTextPlaceHolderKey.audioRecordingPermissionDenied", InstabugCustomTextPlaceHolder.Key.AUDIO_RECORDING_PERMISSION_DENIED);
-        args.put("CustomTextPlaceHolderKey.conversationTextFieldHint", InstabugCustomTextPlaceHolder.Key.CONVERSATION_TEXT_FIELD_HINT);
-        args.put("CustomTextPlaceHolderKey.voiceMessagePressAndHoldToRecord", InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
-        args.put("CustomTextPlaceHolderKey.voiceMessageReleaseToAttach", InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
-        args.put("CustomTextPlaceHolderKey.reportSuccessfullySent", InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);
-        args.put("CustomTextPlaceHolderKey.successDialogHeader", InstabugCustomTextPlaceHolder.Key.SUCCESS_DIALOG_HEADER);
-        args.put("CustomTextPlaceHolderKey.addVideo", InstabugCustomTextPlaceHolder.Key.ADD_VIDEO);
-        args.put("CustomTextPlaceHolderKey.videoPressRecord", InstabugCustomTextPlaceHolder.Key.VIDEO_RECORDING_FAB_BUBBLE_HINT);
-        args.put("CustomTextPlaceHolderKey.betaWelcomeMessageWelcomeStepTitle", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_TITLE);
-        args.put("CustomTextPlaceHolderKey.betaWelcomeMessageWelcomeStepContent", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_CONTENT);
-        args.put("CustomTextPlaceHolderKey.betaWelcomeMessageHowToReportStepTitle", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_TITLE);
-        args.put("CustomTextPlaceHolderKey.betaWelcomeMessageHowToReportStepContent", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_CONTENT);
-        args.put("CustomTextPlaceHolderKey.betaWelcomeMessageFinishStepTitle", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_TITLE);
-        args.put("CustomTextPlaceHolderKey.betaWelcomeMessageFinishStepContent", InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_CONTENT);
-        args.put("CustomTextPlaceHolderKey.liveWelcomeMessageTitle", InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_TITLE);
-        args.put("CustomTextPlaceHolderKey.liveWelcomeMessageContent", InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_CONTENT);
-        args.put("CustomTextPlaceHolderKey.repliesNotificationTeamName", InstabugCustomTextPlaceHolder.Key.CHATS_TEAM_STRING_NAME);
-        args.put("CustomTextPlaceHolderKey.repliesNotificationReplyButton", InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
-        args.put("CustomTextPlaceHolderKey.repliesNotificationDismissButton", InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
-        args.put("CustomTextPlaceHolderKey.surveysStoreRatingThanksTitle", InstabugCustomTextPlaceHolder.Key.SURVEYS_STORE_RATING_THANKS_TITLE);
-        args.put("CustomTextPlaceHolderKey.surveysStoreRatingThanksSubtitle", InstabugCustomTextPlaceHolder.Key.SURVEYS_STORE_RATING_THANKS_SUBTITLE);
-        args.put("CustomTextPlaceHolderKey.reportBugDescription", InstabugCustomTextPlaceHolder.Key.REPORT_BUG_DESCRIPTION);
-        args.put("CustomTextPlaceHolderKey.reportFeedbackDescription", InstabugCustomTextPlaceHolder.Key.REPORT_FEEDBACK_DESCRIPTION);
-        args.put("CustomTextPlaceHolderKey.reportQuestionDescription", InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION_DESCRIPTION);
-        args.put("CustomTextPlaceHolderKey.requestFeatureDescription", InstabugCustomTextPlaceHolder.Key.REQUEST_FEATURE_DESCRIPTION);
-        args.put("CustomTextPlaceHolderKey.discardAlertTitle", InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_TITLE);
-        args.put("CustomTextPlaceHolderKey.discardAlertMessage", InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_BODY);
-        args.put("CustomTextPlaceHolderKey.discardAlertCancel", InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_NEGATIVE_ACTION);
-        args.put("CustomTextPlaceHolderKey.discardAlertAction", InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_POSITIVE_ACTION);
-        args.put("CustomTextPlaceHolderKey.addAttachmentButtonTitleStringName", InstabugCustomTextPlaceHolder.Key.REPORT_ADD_ATTACHMENT_HEADER);
-        args.put("CustomTextPlaceHolderKey.reportReproStepsDisclaimerBody", InstabugCustomTextPlaceHolder.Key.REPORT_REPRO_STEPS_DISCLAIMER_BODY);
-        args.put("CustomTextPlaceHolderKey.reportReproStepsDisclaimerLink", InstabugCustomTextPlaceHolder.Key.REPORT_REPRO_STEPS_DISCLAIMER_LINK);
-        args.put("CustomTextPlaceHolderKey.reproStepsProgressDialogBody", InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_PROGRESS_DIALOG_BODY);
-        args.put("CustomTextPlaceHolderKey.reproStepsListHeader", InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_HEADER);
-        args.put("CustomTextPlaceHolderKey.reproStepsListDescription", InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_DESCRIPTION);
-        args.put("CustomTextPlaceHolderKey.reproStepsListEmptyStateDescription", InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION);
-        args.put("CustomTextPlaceHolderKey.reproStepsListItemTitle", InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
-    }
+    public static final ArgsMap<DismissType> dismissTypes = new ArgsMap<DismissType>() {{
+        put("dismissTypeSubmit", DismissType.SUBMIT);
+        put("dismissTypeCancel", DismissType.CANCEL);
+        put("dismissTypeAddAttachment", DismissType.ADD_ATTACHMENT);
+    }};
 
-    public static void registerInstabugReportTypesArgs(Map<String, Object> args) {
-        args.put("ReportType.bug", BugReporting.ReportType.BUG);
-        args.put("ReportType.feedback", BugReporting.ReportType.FEEDBACK);
-        args.put("ReportType.question", BugReporting.ReportType.QUESTION);
-    }
+    public static final ArgsMap<Integer> actionTypes = new ArgsMap<Integer>() {{
+        put("ActionType.requestNewFeature", ActionType.REQUEST_NEW_FEATURE);
+        put("ActionType.addCommentToFeature", ActionType.ADD_COMMENT_TO_FEATURE);
+    }};
 
-    public static void registerInstabugExtendedBugReportModeArgs(Map<String, Object> args) {
-        args.put("ExtendedBugReportMode.enabledWithRequiredFields", ExtendedBugReport.State.ENABLED_WITH_REQUIRED_FIELDS);
-        args.put("ExtendedBugReportMode.enabledWithOptionalFields", ExtendedBugReport.State.ENABLED_WITH_OPTIONAL_FIELDS);
-        args.put("ExtendedBugReportMode.disabled", ExtendedBugReport.State.DISABLED);
-    }
+    public static ArgsMap<ExtendedBugReport.State> extendedBugReportStates = new ArgsMap<ExtendedBugReport.State>() {{
+        put("ExtendedBugReportMode.enabledWithRequiredFields", ExtendedBugReport.State.ENABLED_WITH_REQUIRED_FIELDS);
+        put("ExtendedBugReportMode.enabledWithOptionalFields", ExtendedBugReport.State.ENABLED_WITH_OPTIONAL_FIELDS);
+        put("ExtendedBugReportMode.disabled", ExtendedBugReport.State.DISABLED);
+    }};
 
-    public static void registerInstabugActionTypesArgs(Map<String, Object> args) {
-        args.put("ActionType.requestNewFeature", ActionType.REQUEST_NEW_FEATURE);
-        args.put("ActionType.addCommentToFeature", ActionType.ADD_COMMENT_TO_FEATURE);
-    }
+    public static final ArgsMap<State> reproStates = new ArgsMap<State>() {{
+        put("ReproStepsMode.enabledWithNoScreenshots", State.ENABLED_WITH_NO_SCREENSHOTS);
+        put("ReproStepsMode.enabled", State.ENABLED);
+        put("ReproStepsMode.disabled", State.DISABLED);
+    }};
 
-    public static void registerReproStepsModeArgs(Map<String, Object> args) {
-        args.put("ReproStepsMode.enabled", State.ENABLED);
-        args.put("ReproStepsMode.disabled", State.DISABLED);
-        args.put("ReproStepsMode.enabledWithNoScreenshots", State.ENABLED_WITH_NO_SCREENSHOTS);
-    }
+    public static final ArgsMap<InstabugLocale> locales = new ArgsMap<InstabugLocale>() {{
+        put("IBGLocale.arabic", InstabugLocale.ARABIC);
+        put("IBGLocale.azerbaijani", InstabugLocale.AZERBAIJANI);
+        put("IBGLocale.chineseSimplified", InstabugLocale.SIMPLIFIED_CHINESE);
+        put("IBGLocale.chineseTraditional", InstabugLocale.TRADITIONAL_CHINESE);
+        put("IBGLocale.czech", InstabugLocale.CZECH);
+        put("IBGLocale.danish", InstabugLocale.DANISH);
+        put("IBGLocale.dutch", InstabugLocale.NETHERLANDS);
+        put("IBGLocale.english", InstabugLocale.ENGLISH);
+        put("IBGLocale.french", InstabugLocale.FRENCH);
+        put("IBGLocale.german", InstabugLocale.GERMAN);
+        put("IBGLocale.indonesian", InstabugLocale.INDONESIAN);
+        put("IBGLocale.italian", InstabugLocale.ITALIAN);
+        put("IBGLocale.japanese", InstabugLocale.JAPANESE);
+        put("IBGLocale.korean", InstabugLocale.KOREAN);
+        put("IBGLocale.norwegian", InstabugLocale.NORWEGIAN);
+        put("IBGLocale.polish", InstabugLocale.POLISH);
+        put("IBGLocale.portugueseBrazil", InstabugLocale.PORTUGUESE_BRAZIL);
+        put("IBGLocale.portuguesePortugal", InstabugLocale.PORTUGUESE_PORTUGAL);
+        put("IBGLocale.romanian", InstabugLocale.ROMANIAN);
+        put("IBGLocale.russian", InstabugLocale.RUSSIAN);
+        put("IBGLocale.spanish", InstabugLocale.SPANISH);
+        put("IBGLocale.slovak", InstabugLocale.SLOVAK);
+        put("IBGLocale.swedish", InstabugLocale.SWEDISH);
+        put("IBGLocale.turkish", InstabugLocale.TURKISH);
+    }};
 
-    public static void registerLogLevelArgs(Map<String, Object> args) {
-        args.put("logLevelNone", LogLevel.NONE);
-        args.put("logLevelError", LogLevel.ERROR);
-        args.put("logLevelWarning", LogLevel.WARNING);
-        args.put("logLevelInfo", LogLevel.INFO);
-        args.put("logLevelDebug", LogLevel.DEBUG);
-        args.put("logLevelVerbose", LogLevel.VERBOSE);
-    }
+    public static final ArgsMap<Key> placeholders = new ArgsMap<Key>() {{
+        put("CustomTextPlaceHolderKey.shakeHint", Key.SHAKE_HINT);
+        put("CustomTextPlaceHolderKey.swipeHint", Key.SWIPE_HINT);
+        put("CustomTextPlaceHolderKey.invalidEmailMessage", Key.INVALID_EMAIL_MESSAGE);
+        put("CustomTextPlaceHolderKey.invalidCommentMessage", Key.INVALID_COMMENT_MESSAGE);
+        put("CustomTextPlaceHolderKey.emailFieldHint", Key.EMAIL_FIELD_HINT);
+        put("CustomTextPlaceHolderKey.commentFieldHintForBugReport", Key.COMMENT_FIELD_HINT_FOR_BUG_REPORT);
+        put("CustomTextPlaceHolderKey.commentFieldHintForFeedback", Key.COMMENT_FIELD_HINT_FOR_FEEDBACK);
+        put("CustomTextPlaceHolderKey.commentFieldHintForQuestion", Key.COMMENT_FIELD_HINT_FOR_QUESTION);
+        put("CustomTextPlaceHolderKey.invocationHeader", Key.INVOCATION_HEADER);
+        put("CustomTextPlaceHolderKey.reportQuestion", Key.REPORT_QUESTION);
+        put("CustomTextPlaceHolderKey.reportBug", Key.REPORT_BUG);
+        put("CustomTextPlaceHolderKey.reportFeedback", Key.REPORT_FEEDBACK);
+        put("CustomTextPlaceHolderKey.conversationsListTitle", Key.CONVERSATIONS_LIST_TITLE);
+        put("CustomTextPlaceHolderKey.addVoiceMessage", Key.ADD_VOICE_MESSAGE);
+        put("CustomTextPlaceHolderKey.addImageFromGallery", Key.ADD_IMAGE_FROM_GALLERY);
+        put("CustomTextPlaceHolderKey.addExtraScreenshot", Key.ADD_EXTRA_SCREENSHOT);
+        put("CustomTextPlaceHolderKey.addVideo", Key.ADD_VIDEO);
+        put("CustomTextPlaceHolderKey.audioRecordingPermissionDenied", Key.AUDIO_RECORDING_PERMISSION_DENIED);
+        put("CustomTextPlaceHolderKey.voiceMessagePressAndHoldToRecord", Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
+        put("CustomTextPlaceHolderKey.voiceMessageReleaseToAttach", Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
+        put("CustomTextPlaceHolderKey.successDialogHeader", Key.SUCCESS_DIALOG_HEADER);
+        put("CustomTextPlaceHolderKey.videoPressRecord", Key.VIDEO_RECORDING_FAB_BUBBLE_HINT);
+        put("CustomTextPlaceHolderKey.conversationTextFieldHint", Key.CONVERSATION_TEXT_FIELD_HINT);
+        put("CustomTextPlaceHolderKey.reportSuccessfullySent", Key.REPORT_SUCCESSFULLY_SENT);
 
+        put("CustomTextPlaceHolderKey.betaWelcomeMessageWelcomeStepTitle", Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_TITLE);
+        put("CustomTextPlaceHolderKey.betaWelcomeMessageWelcomeStepContent", Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_CONTENT);
+        put("CustomTextPlaceHolderKey.betaWelcomeMessageHowToReportStepTitle", Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_TITLE);
+        put("CustomTextPlaceHolderKey.betaWelcomeMessageHowToReportStepContent", Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_CONTENT);
+        put("CustomTextPlaceHolderKey.betaWelcomeMessageFinishStepTitle", Key.BETA_WELCOME_MESSAGE_FINISH_STEP_TITLE);
+        put("CustomTextPlaceHolderKey.betaWelcomeMessageFinishStepContent", Key.BETA_WELCOME_MESSAGE_FINISH_STEP_CONTENT);
+        put("CustomTextPlaceHolderKey.liveWelcomeMessageTitle", Key.LIVE_WELCOME_MESSAGE_TITLE);
+        put("CustomTextPlaceHolderKey.liveWelcomeMessageContent", Key.LIVE_WELCOME_MESSAGE_CONTENT);
+
+        put("CustomTextPlaceHolderKey.surveysStoreRatingThanksTitle", Key.SURVEYS_STORE_RATING_THANKS_TITLE);
+        put("CustomTextPlaceHolderKey.surveysStoreRatingThanksSubtitle", Key.SURVEYS_STORE_RATING_THANKS_SUBTITLE);
+
+        put("CustomTextPlaceHolderKey.reportBugDescription", Key.REPORT_BUG_DESCRIPTION);
+        put("CustomTextPlaceHolderKey.reportFeedbackDescription", Key.REPORT_FEEDBACK_DESCRIPTION);
+        put("CustomTextPlaceHolderKey.reportQuestionDescription", Key.REPORT_QUESTION_DESCRIPTION);
+        put("CustomTextPlaceHolderKey.requestFeatureDescription", Key.REQUEST_FEATURE_DESCRIPTION);
+
+        put("CustomTextPlaceHolderKey.discardAlertTitle", Key.REPORT_DISCARD_DIALOG_TITLE);
+        put("CustomTextPlaceHolderKey.discardAlertMessage", Key.REPORT_DISCARD_DIALOG_BODY);
+        put("CustomTextPlaceHolderKey.discardAlertCancel", Key.REPORT_DISCARD_DIALOG_NEGATIVE_ACTION);
+        put("CustomTextPlaceHolderKey.discardAlertAction", Key.REPORT_DISCARD_DIALOG_POSITIVE_ACTION);
+        put("CustomTextPlaceHolderKey.addAttachmentButtonTitleStringName", Key.REPORT_ADD_ATTACHMENT_HEADER);
+
+        put("CustomTextPlaceHolderKey.reportReproStepsDisclaimerBody", Key.REPORT_REPRO_STEPS_DISCLAIMER_BODY);
+        put("CustomTextPlaceHolderKey.reportReproStepsDisclaimerLink", Key.REPORT_REPRO_STEPS_DISCLAIMER_LINK);
+        put("CustomTextPlaceHolderKey.reproStepsProgressDialogBody", Key.REPRO_STEPS_PROGRESS_DIALOG_BODY);
+        put("CustomTextPlaceHolderKey.reproStepsListHeader", Key.REPRO_STEPS_LIST_HEADER);
+        put("CustomTextPlaceHolderKey.reproStepsListDescription", Key.REPRO_STEPS_LIST_DESCRIPTION);
+        put("CustomTextPlaceHolderKey.reproStepsListEmptyStateDescription", Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION);
+        put("CustomTextPlaceHolderKey.reproStepsListItemTitle", Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
+
+        put("CustomTextPlaceHolderKey.repliesNotificationTeamName", Key.CHATS_TEAM_STRING_NAME);
+        put("CustomTextPlaceHolderKey.repliesNotificationReplyButton", Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
+        put("CustomTextPlaceHolderKey.repliesNotificationDismissButton", Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
+    }};
 }

--- a/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
@@ -1,372 +1,291 @@
 package com.instabug.flutter;
 
+import static org.junit.Assert.assertTrue;
+
+import com.instabug.apm.model.LogLevel;
 import com.instabug.bug.BugReporting;
 import com.instabug.bug.invocation.Option;
+import com.instabug.featuresrequest.ActionType;
 import com.instabug.flutter.util.ArgsRegistry;
 import com.instabug.library.InstabugColorTheme;
-import com.instabug.library.InstabugCustomTextPlaceHolder;
+import com.instabug.library.InstabugCustomTextPlaceHolder.Key;
+import com.instabug.library.OnSdkDismissCallback.DismissType;
+import com.instabug.library.extendedbugreport.ExtendedBugReport;
+import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
+import com.instabug.library.invocation.util.InstabugFloatingButtonEdge;
+import com.instabug.library.invocation.util.InstabugVideoRecordingButtonPosition;
 import com.instabug.library.ui.onboarding.WelcomeMessage;
+import com.instabug.library.visualusersteps.State;
 
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 public class ArgsRegistryTest {
 
     @Test
-    public void given$registerInstabugInvocationEventsArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
-        // given
-        Map<String, Object> map = new HashMap<>();
-        // when
-        ArgsRegistry.registerInstabugInvocationEventsArgs(map);
-        // then
-        Assert.assertEquals(5, map.size());
-        assertAllInvocationEventsArePresent(map);
-    }
+    public void testLogLevels() {
+        Integer[] values = {
+                LogLevel.NONE,
+                LogLevel.ERROR,
+                LogLevel.WARNING,
+                LogLevel.INFO,
+                LogLevel.DEBUG,
+                LogLevel.VERBOSE,
+        };
 
-    @Test
-    public void given$registerWelcomeMessageArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
-        // given
-        Map<String, Object> map = new HashMap<>();
-        // when
-        ArgsRegistry.registerWelcomeMessageArgs(map);
-        // then
-        Assert.assertEquals(3, map.size());
-        assertAllWelcomeMessageStatesArePresent(map);
-    }
-
-    @Test
-    public void given$registerLocaleArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
-        // given
-        Map<String, Object> map = new HashMap<>();
-        // when
-        ArgsRegistry.registerLocaleArgs(map);
-        // then
-        assertAllSupportedLocalesArePresent(map);
-    }
-
-    @Test
-    public void given$ArgsRegistryIsInitialized_whenQuery_thenShouldMatchCriteria() {
-        Map<String, Object> args = ArgsRegistry.ARGS;
-        assertAllInvocationEventsArePresent(args);
-        assertAllWelcomeMessageStatesArePresent(args);
-        assertAllSupportedLocalesArePresent(args);
-        assertAllColorThemesArePresent(args);
-        assertAllInvocationModesArePresent(args);
-        assertAllInvocationOptionsArePresent(args);
-        assertAllSupportedCustomTextPlaceHolderKeysArePresent(args);
-    }
-
-    @Test
-    public void givenFabInvocationIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
-        // when
-        InstabugInvocationEvent deserializedValue = ArgsRegistry.getDeserializedValue(
-                "InvocationEvent.floatingButton");
-        // then
-        Assert.assertNotNull(deserializedValue);
-        Assert.assertEquals(InstabugInvocationEvent.FLOATING_BUTTON, deserializedValue);
-    }
-
-    @Test
-    public void givenWelcomeMessageBetaIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
-        // when
-        WelcomeMessage.State deserializedValue = ArgsRegistry.getDeserializedValue(
-                "WelcomeMessageMode.beta");
-        // then
-        Assert.assertNotNull(deserializedValue);
-        Assert.assertEquals(WelcomeMessage.State.BETA, deserializedValue);
-    }
-
-    @Test
-    public void givenEnglishLocaleIsPresent_when$getDeserializedValue_thenShouldReturnNonNullLocale() {
-        // when
-        Locale actualLocale = ArgsRegistry.getDeserializedValue("IBGLocale.english");
-        // then
-        Assert.assertNotNull(actualLocale);
-        Assert.assertEquals("en", actualLocale.getLanguage());
-    }
-
-    @Test
-    public void given$registerColorThemeArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
-        // given
-        Map<String, Object> map = new HashMap<>();
-        // when
-        ArgsRegistry.registerColorThemeArgs(map);
-        // then
-        assertAllColorThemesArePresent(map);
-    }
-
-    @Test
-    public void givenShakeHintIsPresent_when$getDeserializedValue_thenShouldReturnNonNullKey() {
-        // when
-        InstabugCustomTextPlaceHolder.Key actualKey = ArgsRegistry
-                .getDeserializedValue("CustomTextPlaceHolderKey.shakeHint");
-        // then
-        Assert.assertNotNull(actualKey);
-        Assert.assertEquals(InstabugCustomTextPlaceHolder.Key.SHAKE_HINT, actualKey);
-
-    }
-
-    @Test
-    public void given$registerPlaceHolderKeysArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
-        // given
-        Map<String, Object> map = new HashMap<>();
-        // when
-        ArgsRegistry.registerCustomTextPlaceHolderKeysArgs(map);
-        // then
-        assertAllSupportedCustomTextPlaceHolderKeysArePresent(map);
-    }
-
-    @Ignore
-    @Test
-    public void duplicate_given$registerPlaceHolderKeysArgsIsCalledOnAMap_whenQuery_thenShouldMatchCriteria() {
-        // given
-        Map<String, Object> map = new HashMap<>();
-        // when
-        ArgsRegistry.registerCustomTextPlaceHolderKeysArgs(map);
-        // then
-        assertAllSupportedCustomTextPlaceHolderKeysArePresent(map, getAllCustomTextPlaceHolderKeys());
-    }
-
-    private void assertAllInvocationEventsArePresent(Map<String, Object> map) {
-        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.NONE));
-        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SHAKE));
-        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.FLOATING_BUTTON));
-        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.SCREENSHOT));
-        Assert.assertTrue(map.containsValue(InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT));
-    }
-
-    private void assertAllWelcomeMessageStatesArePresent(Map<String, Object> map) {
-        Assert.assertTrue(map.containsValue(WelcomeMessage.State.LIVE));
-        Assert.assertTrue(map.containsValue(WelcomeMessage.State.BETA));
-        Assert.assertTrue(map.containsValue(WelcomeMessage.State.DISABLED));
-    }
-
-    private void assertAllSupportedLocalesArePresent(Map<String, Object> map) {
-        // source of truth
-        List<Locale> expectedLocales = getCurrentlySupportLanguagesByTheSDK();
-        // actual
-        List<Locale> actualLocales = new ArrayList<>();
-        for (Map.Entry m : map.entrySet()) {
-            if (m.getValue() instanceof Locale) {
-                actualLocales.add((Locale) m.getValue());
-            }
-        }
-        StringBuilder stringBuilder = new StringBuilder();
-        for (Locale expectedLocale : expectedLocales) {
-            if (!actualLocales.contains(expectedLocale)) {
-                stringBuilder.append(expectedLocale.getLanguage())
-                        .append(" - ")
-                        .append(expectedLocale.getCountry())
-                        .append(" is missing")
-                        .append("\n");
-            }
-        }
-        String missingLangs = stringBuilder.toString();
-        if (!missingLangs.isEmpty()) {
-            Assert.fail(missingLangs);
+        for (Integer value : values) {
+            assertTrue(ArgsRegistry.logLevels.containsValue(value));
         }
     }
 
-    private void assertAllColorThemesArePresent(Map<String, Object> map) {
-        Assert.assertTrue(map.containsValue(InstabugColorTheme.InstabugColorThemeDark));
-        Assert.assertTrue(map.containsValue(InstabugColorTheme.InstabugColorThemeLight));
-    }
+    @Test
+    public void testInvocationEvents() {
+        InstabugInvocationEvent[] values = {
+                InstabugInvocationEvent.NONE,
+                InstabugInvocationEvent.SHAKE,
+                InstabugInvocationEvent.FLOATING_BUTTON,
+                InstabugInvocationEvent.SCREENSHOT,
+                InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT,
+        };
 
-    private void assertAllInvocationModesArePresent(Map<String, Object> map) {
-        Assert.assertTrue(map.containsValue(BugReporting.ReportType.BUG));
-        Assert.assertTrue(map.containsValue(BugReporting.ReportType.FEEDBACK));
-    }
-
-    private void assertAllInvocationOptionsArePresent(Map<String, Object> map) {
-        Assert.assertTrue(map.containsValue(Option.COMMENT_FIELD_REQUIRED));
-        Assert.assertTrue(map.containsValue(Option.DISABLE_POST_SENDING_DIALOG));
-        Assert.assertTrue(map.containsValue(Option.EMAIL_FIELD_HIDDEN));
-        Assert.assertTrue(map.containsValue(Option.EMAIL_FIELD_OPTIONAL));
-    }
-
-    private void assertAllSupportedCustomTextPlaceHolderKeysArePresent(Map<String, Object> map,
-                                                                       List<InstabugCustomTextPlaceHolder.Key> expectedKeys) {
-        // actual
-        List<InstabugCustomTextPlaceHolder.Key> actualKeys = new ArrayList<>();
-        for (Map.Entry m : map.entrySet()) {
-            if (m.getValue() instanceof InstabugCustomTextPlaceHolder.Key) {
-                actualKeys.add((InstabugCustomTextPlaceHolder.Key) m.getValue());
-            }
-        }
-        StringBuilder stringBuilder = new StringBuilder();
-        for (InstabugCustomTextPlaceHolder.Key expectedKey : expectedKeys) {
-            if (!actualKeys.contains(expectedKey)) {
-                stringBuilder.append(expectedKey)
-                        .append(" is missing")
-                        .append("\n");
-            }
-        }
-        String missingKeys = stringBuilder.toString();
-        if (!missingKeys.isEmpty()) {
-            Assert.fail(missingKeys);
+        for (InstabugInvocationEvent value : values) {
+            assertTrue(ArgsRegistry.invocationEvents.containsValue(value));
         }
     }
 
-    private void assertAllSupportedCustomTextPlaceHolderKeysArePresent(Map<String, Object> map) {
-        // source of truth
-        List<InstabugCustomTextPlaceHolder.Key> expectedKeys = getCurrentlySupportedKeysBySDK();
-        assertAllSupportedCustomTextPlaceHolderKeysArePresent(map, expectedKeys);
+    @Test
+    public void testInvocationOptions() {
+        Integer[] values = {
+                Option.EMAIL_FIELD_HIDDEN,
+                Option.EMAIL_FIELD_OPTIONAL,
+                Option.COMMENT_FIELD_REQUIRED,
+                Option.DISABLE_POST_SENDING_DIALOG,
+        };
+
+        for (Integer value : values) {
+            assertTrue(ArgsRegistry.invocationOptions.containsValue(value));
+        }
     }
 
-    private List<Locale> getCurrentlySupportLanguagesByTheSDK() {
-        List<Locale> langs = new ArrayList<>();
-        langs.add(new Locale("en", ""));
-        langs.add(new Locale("ar", ""));
-        langs.add(new Locale("de", ""));
-        langs.add(new Locale("es", ""));
-        langs.add(new Locale("fr", ""));
-        langs.add(new Locale("it", ""));
-        langs.add(new Locale("ja", ""));
-        langs.add(new Locale("ko", ""));
-        langs.add(new Locale("pl", ""));
-        langs.add(new Locale("pt", "BR"));
-        langs.add(new Locale("pt", "PT"));
-        langs.add(new Locale("ru", ""));
-        langs.add(new Locale("sv", ""));
-        langs.add(new Locale("tr", ""));
-        langs.add(new Locale("zh", "CN"));
-        langs.add(new Locale("zh", "TW"));
-        langs.add(new Locale("cs", ""));
-        langs.add(new Locale("in", ""));
-        langs.add(new Locale("da", ""));
-        langs.add(new Locale("sk", ""));
-        langs.add(new Locale("nl", ""));
-        langs.add(new Locale("no", ""));
-        return langs;
+    @Test
+    public void testColorThemes() {
+        InstabugColorTheme[] values = {
+                InstabugColorTheme.InstabugColorThemeLight,
+                InstabugColorTheme.InstabugColorThemeDark,
+        };
+
+        for (InstabugColorTheme value : values) {
+            assertTrue(ArgsRegistry.colorThemes.containsValue(value));
+        }
     }
 
-    private List<InstabugCustomTextPlaceHolder.Key> getCurrentlySupportedKeysBySDK() {
-        List<InstabugCustomTextPlaceHolder.Key> keys = new ArrayList<>();
-        keys.add(InstabugCustomTextPlaceHolder.Key.SHAKE_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SWIPE_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.INVALID_EMAIL_MESSAGE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.INVALID_COMMENT_MESSAGE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.INVOCATION_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_BUG);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_FEEDBACK);
-        keys.add(InstabugCustomTextPlaceHolder.Key.EMAIL_FIELD_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.COMMENT_FIELD_HINT_FOR_BUG_REPORT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.COMMENT_FIELD_HINT_FOR_FEEDBACK);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_VOICE_MESSAGE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_IMAGE_FROM_GALLERY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_EXTRA_SCREENSHOT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATIONS_LIST_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.AUDIO_RECORDING_PERMISSION_DENIED);
-        keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATION_TEXT_FIELD_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
-        keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SUCCESS_DIALOG_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_VIDEO);
-        keys.add(InstabugCustomTextPlaceHolder.Key.VIDEO_RECORDING_FAB_BUBBLE_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.CHATS_TEAM_STRING_NAME);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_STORE_RATING_THANKS_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_STORE_RATING_THANKS_SUBTITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_BUG_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_FEEDBACK_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REQUEST_FEATURE_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_BODY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_NEGATIVE_ACTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_POSITIVE_ACTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_ADD_ATTACHMENT_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_REPRO_STEPS_DISCLAIMER_BODY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_REPRO_STEPS_DISCLAIMER_LINK);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_PROGRESS_DIALOG_BODY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
-        return keys;
+    @Test
+    public void testFloatingButtonEdges() {
+        InstabugFloatingButtonEdge[] values = {
+                InstabugFloatingButtonEdge.LEFT,
+                InstabugFloatingButtonEdge.RIGHT,
+        };
+
+        for (InstabugFloatingButtonEdge value : values) {
+            assertTrue(ArgsRegistry.floatingButtonEdges.containsValue(value));
+        }
     }
 
-    private List<InstabugCustomTextPlaceHolder.Key> getAllCustomTextPlaceHolderKeys() {
-        List<InstabugCustomTextPlaceHolder.Key> keys = new ArrayList<>();
-        keys.add(InstabugCustomTextPlaceHolder.Key.SHAKE_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SWIPE_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.INVALID_EMAIL_MESSAGE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.INVALID_COMMENT_MESSAGE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.INVOCATION_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_BUG);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_FEEDBACK);
-        keys.add(InstabugCustomTextPlaceHolder.Key.EMAIL_FIELD_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.COMMENT_FIELD_HINT_FOR_BUG_REPORT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.COMMENT_FIELD_HINT_FOR_FEEDBACK);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_VOICE_MESSAGE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_IMAGE_FROM_GALLERY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_EXTRA_SCREENSHOT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATIONS_LIST_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.AUDIO_RECORDING_PERMISSION_DENIED);
-        keys.add(InstabugCustomTextPlaceHolder.Key.CONVERSATION_TEXT_FIELD_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD);
-        keys.add(InstabugCustomTextPlaceHolder.Key.VOICE_MESSAGE_RELEASE_TO_ATTACH);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_SUCCESSFULLY_SENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SUCCESS_DIALOG_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.ADD_VIDEO);
-        keys.add(InstabugCustomTextPlaceHolder.Key.VIDEO_RECORDING_FAB_BUBBLE_HINT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.BETA_WELCOME_MESSAGE_FINISH_STEP_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.LIVE_WELCOME_MESSAGE_CONTENT);
-        keys.add(InstabugCustomTextPlaceHolder.Key.VIDEO_PLAYER_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.FEATURES_REQUEST);
-        keys.add(InstabugCustomTextPlaceHolder.Key.FEATURES_REQUEST_ADD_FEATURE_TOAST);
-        keys.add(InstabugCustomTextPlaceHolder.Key.FEATURES_REQUEST_ADD_FEATURE_THANKS_MESSAGE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_WELCOME_SCREEN_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_WELCOME_SCREEN_SUBTITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_WELCOME_SCREEN_BUTTON);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REQUEST_FEATURE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.CHATS_TEAM_STRING_NAME);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_STORE_RATING_THANKS_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.SURVEYS_STORE_RATING_THANKS_SUBTITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_BUG_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_FEEDBACK_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REQUEST_FEATURE_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_TITLE);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_BODY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_NEGATIVE_ACTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_DISCARD_DIALOG_POSITIVE_ACTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_ADD_ATTACHMENT_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_REPRO_STEPS_DISCLAIMER_BODY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPORT_REPRO_STEPS_DISCLAIMER_LINK);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_PROGRESS_DIALOG_BODY);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_HEADER);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION);
-        keys.add(InstabugCustomTextPlaceHolder.Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE);
-        return keys;
+    @Test
+    public void testRecordButtonPositions() {
+        InstabugVideoRecordingButtonPosition[] values = {
+                InstabugVideoRecordingButtonPosition.TOP_LEFT,
+                InstabugVideoRecordingButtonPosition.TOP_RIGHT,
+                InstabugVideoRecordingButtonPosition.BOTTOM_LEFT,
+                InstabugVideoRecordingButtonPosition.BOTTOM_RIGHT,
+        };
+
+        for (InstabugVideoRecordingButtonPosition value : values) {
+            assertTrue(ArgsRegistry.recordButtonPositions.containsValue(value));
+        }
     }
+
+    @Test
+    public void testwelcomeMessageStates() {
+        WelcomeMessage.State[] values = {
+                WelcomeMessage.State.LIVE,
+                WelcomeMessage.State.BETA,
+                WelcomeMessage.State.DISABLED,
+        };
+
+        for (WelcomeMessage.State value : values) {
+            assertTrue(ArgsRegistry.welcomeMessageStates.containsValue(value));
+        }
+    }
+
+    @Test
+    public void testReportTypes() {
+        Integer[] values = {
+                BugReporting.ReportType.BUG,
+                BugReporting.ReportType.FEEDBACK,
+                BugReporting.ReportType.QUESTION,
+        };
+
+        for (Integer value : values) {
+            assertTrue(ArgsRegistry.reportTypes.containsValue(value));
+        }
+    }
+
+    @Test
+    public void testDismissTypes() {
+        DismissType[] values = {
+                DismissType.SUBMIT,
+                DismissType.CANCEL,
+                DismissType.ADD_ATTACHMENT,
+        };
+
+        for (DismissType value : values) {
+            assertTrue(ArgsRegistry.dismissTypes.containsValue(value));
+        }
+    }
+
+    @Test
+    public void testActionTypes() {
+        Integer[] values = {
+                ActionType.REQUEST_NEW_FEATURE,
+                ActionType.ADD_COMMENT_TO_FEATURE,
+        };
+
+        for (Integer value : values) {
+            assertTrue(ArgsRegistry.actionTypes.containsValue(value));
+        }
+    }
+
+    @Test
+    public void testExtendedBugReportStates() {
+        ExtendedBugReport.State[] values = {
+                ExtendedBugReport.State.ENABLED_WITH_REQUIRED_FIELDS,
+                ExtendedBugReport.State.ENABLED_WITH_OPTIONAL_FIELDS,
+                ExtendedBugReport.State.DISABLED,
+        };
+
+        for (ExtendedBugReport.State value : values) {
+            assertTrue(ArgsRegistry.extendedBugReportStates.containsValue(value));
+        }
+    }
+
+
+    @Test
+    public void testReproStates() {
+        State[] values = {
+                State.ENABLED_WITH_NO_SCREENSHOTS,
+                State.ENABLED,
+                State.DISABLED,
+        };
+
+        for (State value : values) {
+            assertTrue(ArgsRegistry.reproStates.containsValue(value));
+        }
+    }
+
+
+    @Test
+    public void testLocales() {
+        InstabugLocale[] values = {
+                InstabugLocale.ARABIC,
+                InstabugLocale.AZERBAIJANI,
+                InstabugLocale.SIMPLIFIED_CHINESE,
+                InstabugLocale.TRADITIONAL_CHINESE,
+                InstabugLocale.CZECH,
+                InstabugLocale.DANISH,
+                InstabugLocale.NETHERLANDS,
+                InstabugLocale.ENGLISH,
+                InstabugLocale.FRENCH,
+                InstabugLocale.GERMAN,
+                InstabugLocale.INDONESIAN,
+                InstabugLocale.ITALIAN,
+                InstabugLocale.JAPANESE,
+                InstabugLocale.KOREAN,
+                InstabugLocale.NORWEGIAN,
+                InstabugLocale.POLISH,
+                InstabugLocale.PORTUGUESE_BRAZIL,
+                InstabugLocale.PORTUGUESE_PORTUGAL,
+                InstabugLocale.ROMANIAN,
+                InstabugLocale.RUSSIAN,
+                InstabugLocale.SPANISH,
+                InstabugLocale.SLOVAK,
+                InstabugLocale.SWEDISH,
+                InstabugLocale.TURKISH,
+        };
+
+        for (InstabugLocale value : values) {
+            assertTrue(ArgsRegistry.locales.containsValue(value));
+        }
+    }
+
+
+    @Test
+    public void testPlaceholder() {
+        Key[] values = {
+                Key.SHAKE_HINT,
+                Key.SWIPE_HINT,
+                Key.INVALID_EMAIL_MESSAGE,
+                Key.INVALID_COMMENT_MESSAGE,
+                Key.EMAIL_FIELD_HINT,
+                Key.COMMENT_FIELD_HINT_FOR_BUG_REPORT,
+                Key.COMMENT_FIELD_HINT_FOR_FEEDBACK,
+                Key.COMMENT_FIELD_HINT_FOR_QUESTION,
+                Key.INVOCATION_HEADER,
+                Key.REPORT_QUESTION,
+                Key.REPORT_BUG,
+                Key.REPORT_FEEDBACK,
+                Key.CONVERSATIONS_LIST_TITLE,
+                Key.ADD_VOICE_MESSAGE,
+                Key.ADD_IMAGE_FROM_GALLERY,
+                Key.ADD_EXTRA_SCREENSHOT,
+                Key.ADD_VIDEO,
+                Key.AUDIO_RECORDING_PERMISSION_DENIED,
+                Key.VOICE_MESSAGE_PRESS_AND_HOLD_TO_RECORD,
+                Key.VOICE_MESSAGE_RELEASE_TO_ATTACH,
+                Key.SUCCESS_DIALOG_HEADER,
+                Key.VIDEO_RECORDING_FAB_BUBBLE_HINT,
+                Key.CONVERSATION_TEXT_FIELD_HINT,
+                Key.REPORT_SUCCESSFULLY_SENT,
+
+                Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_TITLE,
+                Key.BETA_WELCOME_MESSAGE_WELCOME_STEP_CONTENT,
+                Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_TITLE,
+                Key.BETA_WELCOME_MESSAGE_HOW_TO_REPORT_STEP_CONTENT,
+                Key.BETA_WELCOME_MESSAGE_FINISH_STEP_TITLE,
+                Key.BETA_WELCOME_MESSAGE_FINISH_STEP_CONTENT,
+                Key.LIVE_WELCOME_MESSAGE_TITLE,
+                Key.LIVE_WELCOME_MESSAGE_CONTENT,
+
+                Key.SURVEYS_STORE_RATING_THANKS_TITLE,
+                Key.SURVEYS_STORE_RATING_THANKS_SUBTITLE,
+
+                Key.REPORT_BUG_DESCRIPTION,
+                Key.REPORT_FEEDBACK_DESCRIPTION,
+                Key.REPORT_QUESTION_DESCRIPTION,
+                Key.REQUEST_FEATURE_DESCRIPTION,
+
+                Key.REPORT_DISCARD_DIALOG_TITLE,
+                Key.REPORT_DISCARD_DIALOG_BODY,
+                Key.REPORT_DISCARD_DIALOG_NEGATIVE_ACTION,
+                Key.REPORT_DISCARD_DIALOG_POSITIVE_ACTION,
+                Key.REPORT_ADD_ATTACHMENT_HEADER,
+
+                Key.REPORT_REPRO_STEPS_DISCLAIMER_BODY,
+                Key.REPORT_REPRO_STEPS_DISCLAIMER_LINK,
+                Key.REPRO_STEPS_PROGRESS_DIALOG_BODY,
+                Key.REPRO_STEPS_LIST_HEADER,
+                Key.REPRO_STEPS_LIST_DESCRIPTION,
+                Key.REPRO_STEPS_LIST_EMPTY_STATE_DESCRIPTION,
+                Key.REPRO_STEPS_LIST_ITEM_NUMBERING_TITLE,
+
+                Key.CHATS_TEAM_STRING_NAME,
+                Key.REPLIES_NOTIFICATION_REPLY_BUTTON,
+                Key.REPLIES_NOTIFICATION_DISMISS_BUTTON,
+        };
+
+        for (Key value : values) {
+            assertTrue(ArgsRegistry.placeholders.containsValue(value));
+        }
+    }
+
 }


### PR DESCRIPTION
## Description of the change

The two `ArgsRegistry` methods `getDeserializedValue` and `getRawValue` were not type safe at runtime.
This PR provide a type-safe way to achieve enum resolution on Android.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
