### PR TITLE
[MOB-10849] Bump Android SDK to `v11.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
+* Bumps Instabug Android SDK to v11.6.0
 * Adds BugReporting.setDisclaimerText API
 * Adds BugReporting.setCommentMinimumCharacterCount API
 * Deprecates Instabug.enableAndroid and Instabug.disableAndroid APIs in favour of a new API Instabug.setEnabled, which works on both platforms
+* Fixes APM network logging on Android
 * Fixes main thread violation on Android
 * Fixes an issue with request and response headers parameters type causing network requests not getting logged on iOS
 * Uses pigeon for internal communication between Flutter and the host platform

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.instabug.library:instabug:11.5.1'
+    implementation 'com.instabug.library:instabug:11.6.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"
 }


### PR DESCRIPTION
## Description of the change
> Description goes here
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
