### PR TITLE
[MOB-10573] Support `setSdkDebugLogsLevel` on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Unreleased
 
 * Bumps Instabug Android SDK to v11.7.0
+* Adds new string keys: okButtonText, audio, image, screenRecording, messagesNotificationAndOthers, insufficientContentTitle, insufficientContentMessage
 * Fixes APM network logging on Android
 * Fixes a NullPointerException when overriding a string key that doesn't exist on Android
 * Removes redundant native logs
-* Adds new string keys: okButtonText, audio, image, screenRecording, messagesNotificationAndOthers, insufficientContentTitle, insufficientContentMessage
+* Deprecates Instabug.setDebugEnabled and APM.setLogLevel APIs in favour of Instabug.setSdkDebugLogsLevel, which controls the verbosity of SDK logs on both platforms
 
 ## 11.5.0 (2022-11-24)
 

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -248,11 +248,6 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
     }
 
     @Override
-    public void setDebugEnabled(@NonNull Boolean enabled) {
-        Instabug.setDebugEnabled(enabled);
-    }
-
-    @Override
     public void setSdkDebugLogsLevel(@NonNull String level) {
         final int sdkLogLevel = ArgsRegistry.sdkLogLevels.get(level);
         Instabug.setSdkDebugLogsLevel(sdkLogLevel);

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -254,7 +254,8 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
     @Override
     public void setSdkDebugLogsLevel(@NonNull String level) {
-        // iOS Only
+        final int sdkLogLevel = ArgsRegistry.sdkLogLevels.get(level);
+        Instabug.setSdkDebugLogsLevel(sdkLogLevel);
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
@@ -201,4 +201,11 @@ public final class ArgsRegistry {
         put("CustomTextPlaceHolderKey.messagesNotificationAndOthers", Key.CHATS_MULTIPLE_MESSAGE_NOTIFICATION);
         put("CustomTextPlaceHolderKey.insufficientContentMessage", Key.COMMENT_FIELD_INSUFFICIENT_CONTENT);
     }};
+
+    public static final ArgsMap<Integer> sdkLogLevels = new ArgsMap<Integer>() {{
+        put("IBGSDKDebugLogsLevel.none", com.instabug.library.LogLevel.NONE);
+        put("IBGSDKDebugLogsLevel.error", com.instabug.library.LogLevel.ERROR);
+        put("IBGSDKDebugLogsLevel.debug", com.instabug.library.LogLevel.DEBUG);
+        put("IBGSDKDebugLogsLevel.verbose", com.instabug.library.LogLevel.VERBOSE);
+    }};
 }

--- a/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
+++ b/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
@@ -369,14 +369,13 @@ public class InstabugApiTest {
         mInstabug.verify(Instabug::getAllUserAttributes);
     }
 
-    @SuppressWarnings("deprecation")
     @Test
-    public void testSetDebugEnabled() {
-        boolean isEnabled = true;
+    public void testSetSdkDebugLogsLevel() {
+        String level = "IBGSDKDebugLogsLevel.debug";
 
-        api.setDebugEnabled(isEnabled);
+        api.setSdkDebugLogsLevel(level);
 
-        mInstabug.verify(() -> Instabug.setDebugEnabled(isEnabled));
+        mInstabug.verify(() -> Instabug.setSdkDebugLogsLevel(com.instabug.library.LogLevel.DEBUG));
     }
 
     @Test

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -140,10 +140,6 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
     completion(Instabug.userAttributes, nil);
 }
 
-- (void)setDebugEnabledEnabled:(NSNumber *)enabled error:(FlutterError *_Nullable *_Nonnull)error {
-    // Android Only
-}
-
 - (void)setSdkDebugLogsLevelLevel:(NSString *)level error:(FlutterError *_Nullable *_Nonnull)error {
     IBGSDKDebugLogsLevel resolvedLevel = (ArgsRegistry.sdkLogLevels[level]).integerValue;
     [Instabug setSdkDebugLogsLevel:resolvedLevel];

--- a/lib/src/modules/apm.dart
+++ b/lib/src/modules/apm.dart
@@ -36,6 +36,9 @@ class APM {
 
   /// Sets log Level to determine level of details in a log
   /// [logLevel] Enum value to determine the level
+  @Deprecated(
+    "Use [Instabug.setSdkDebugLogsLevel] instead. ",
+  )
   static Future<void> setLogLevel(LogLevel logLevel) async {
     return _host.setLogLevel(logLevel.toString());
   }

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -291,9 +291,17 @@ class Instabug {
   /// Android only
   /// Enable/disable SDK logs
   /// [debugEnabled] desired state of debug mode.
+  @Deprecated(
+    "Use [Instabug.setSdkDebugLogsLevel] instead. This will work on both Android and iOS. ",
+  )
   static Future<void> setDebugEnabled(bool debugEnabled) async {
     if (IBGBuildInfo.instance.isAndroid) {
-      return _host.setDebugEnabled(debugEnabled);
+      if (debugEnabled) {
+        return _host
+            .setSdkDebugLogsLevel(IBGSDKDebugLogsLevel.verbose.toString());
+      } else {
+        return _host.setSdkDebugLogsLevel(IBGSDKDebugLogsLevel.none.toString());
+      }
     }
   }
 

--- a/pigeons/instabug.api.dart
+++ b/pigeons/instabug.api.dart
@@ -39,7 +39,6 @@ abstract class InstabugHostApi {
   @async
   Map<String, String>? getUserAttributes();
 
-  void setDebugEnabled(bool enabled);
   void setSdkDebugLogsLevel(String level);
 
   void setReproStepsMode(String mode);

--- a/test/apm_test.dart
+++ b/test/apm_test.dart
@@ -61,6 +61,7 @@ void main() {
   test('[setLogLevel] should call host method', () async {
     const level = LogLevel.debug;
 
+    // ignore: deprecated_member_use_from_same_package
     await APM.setLogLevel(level);
 
     verify(

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -270,14 +270,17 @@ void main() {
     ).called(1);
   });
 
-  test('[setDebugEnabled] should call host method', () async {
+  test('[setDebugEnabled] should call setSdkDebugLogsLevel host method',
+      () async {
     const enabled = true;
+    const level = IBGSDKDebugLogsLevel.verbose;
     when(mBuildInfo.isAndroid).thenReturn(true);
 
+    // ignore: deprecated_member_use_from_same_package
     await Instabug.setDebugEnabled(enabled);
 
     verify(
-      mHost.setDebugEnabled(enabled),
+      mHost.setSdkDebugLogsLevel(level.toString()),
     ).called(1);
   });
 


### PR DESCRIPTION
## Description of the change

We had two different native APIs for SDK logs, which were mapped accordingly in Flutter. Since this is now unified natively, this PR does the following:

1. Adds `setSdkDebugLogsLevel` implementation on Android.
2. Deprecates `setDebugEnabled` and updates its implementation to use the new API when called on Android, in addition to the related unit tests.
3. Removes setDebugEnabled from the native bridge.

Note:
This is based on an internal snapshot, so the Android tests are expected to fail until we bump to the Android release, including this API.

To-Do:

Rebase the PR after bumping the Android version
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
