### PR TITLE
[MOB-10637] Add Overridable String Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixes APM network logging on Android
 * Fixes a NullPointerException when overriding a string key that doesn't exist on Android
 * Removes redundant native logs
+* Adds new string keys: okButtonText, audio, image, screenRecording, messagesNotificationAndOthers, insufficientContentTitle, insufficientContentMessage
 
 ## 11.5.0 (2022-11-24)
 

--- a/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
@@ -193,5 +193,12 @@ public final class ArgsRegistry {
         put("CustomTextPlaceHolderKey.repliesNotificationTeamName", Key.CHATS_TEAM_STRING_NAME);
         put("CustomTextPlaceHolderKey.repliesNotificationReplyButton", Key.REPLIES_NOTIFICATION_REPLY_BUTTON);
         put("CustomTextPlaceHolderKey.repliesNotificationDismissButton", Key.REPLIES_NOTIFICATION_DISMISS_BUTTON);
+
+        put("CustomTextPlaceHolderKey.okButtonText", Key.BUG_ATTACHMENT_DIALOG_OK_BUTTON);
+        put("CustomTextPlaceHolderKey.audio", Key.CHATS_TYPE_AUDIO);
+        put("CustomTextPlaceHolderKey.image", Key.CHATS_TYPE_IMAGE);
+        put("CustomTextPlaceHolderKey.screenRecording", Key.CHATS_TYPE_VIDEO);
+        put("CustomTextPlaceHolderKey.messagesNotificationAndOthers", Key.CHATS_MULTIPLE_MESSAGE_NOTIFICATION);
+        put("CustomTextPlaceHolderKey.insufficientContentMessage", Key.COMMENT_FIELD_INSUFFICIENT_CONTENT);
     }};
 }

--- a/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
@@ -281,6 +281,13 @@ public class ArgsRegistryTest {
                 Key.CHATS_TEAM_STRING_NAME,
                 Key.REPLIES_NOTIFICATION_REPLY_BUTTON,
                 Key.REPLIES_NOTIFICATION_DISMISS_BUTTON,
+
+                Key.BUG_ATTACHMENT_DIALOG_OK_BUTTON,
+                Key.CHATS_TYPE_AUDIO,
+                Key.CHATS_TYPE_IMAGE,
+                Key.CHATS_TYPE_VIDEO,
+                Key.CHATS_MULTIPLE_MESSAGE_NOTIFICATION,
+                Key.COMMENT_FIELD_INSUFFICIENT_CONTENT,
         };
 
         for (Key value : values) {

--- a/ios/Classes/Util/ArgsRegistry.m
+++ b/ios/Classes/Util/ArgsRegistry.m
@@ -199,6 +199,14 @@
         @"CustomTextPlaceHolderKey.reproStepsListDescription" : kIBGReproStepsListHeader,
         @"CustomTextPlaceHolderKey.reproStepsListEmptyStateDescription" : kIBGReproStepsListEmptyStateLabel,
         @"CustomTextPlaceHolderKey.reproStepsListItemTitle" : kIBGReproStepsListItemName,
+        
+        @"CustomTextPlaceHolderKey.okButtonText" : kIBGOkButtonTitleStringName,
+        @"CustomTextPlaceHolderKey.audio" : kIBGAudioStringName,
+        @"CustomTextPlaceHolderKey.image" : kIBGImageStringName,
+        @"CustomTextPlaceHolderKey.screenRecording" : kIBGScreenRecordingStringName,
+        @"CustomTextPlaceHolderKey.messagesNotificationAndOthers" : kIBGMessagesNotificationTitleMultipleMessagesStringName,
+        @"CustomTextPlaceHolderKey.insufficientContentTitle" : kIBGInsufficientContentTitleStringName,
+        @"CustomTextPlaceHolderKey.insufficientContentMessage" : kIBGInsufficientContentMessageStringName,
     };
 }
 

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -111,6 +111,13 @@ enum CustomTextPlaceHolderKey {
   reproStepsListDescription,
   reproStepsListEmptyStateDescription,
   reproStepsListItemTitle,
+  okButtonText,
+  audio,
+  image,
+  screenRecording,
+  messagesNotificationAndOthers,
+  insufficientContentTitle,
+  insufficientContentMessage,
 }
 
 enum ReproStepsMode { enabled, disabled, enabledWithNoScreenshots }


### PR DESCRIPTION
## Description of the change
Add these string keys: `okButtonText`, `audio`, `image`, `screenRecording`, `messagesNotificationAndOthers`, `insufficientContentTitle`, `insufficientContentMessage` with their mapping on both platforms (if relevant).

Note:
This is based on an internal snapshot, so the Android tests are expected to fail until we bump to the Android release including the new keys.

To-Do:
Rebase the PR after bumping the Android version ✅ 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
