### PR TITLE
[MOB-10900] Remove Internals from API Reference

### DIFF
--- a/lib/src/modules/apm.dart
+++ b/lib/src/modules/apm.dart
@@ -2,7 +2,7 @@
 
 import 'dart:async';
 
-import 'package:instabug_flutter/generated/apm.api.g.dart';
+import 'package:instabug_flutter/src/generated/apm.api.g.dart';
 import 'package:instabug_flutter/src/models/network_data.dart';
 import 'package:instabug_flutter/src/models/trace.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
@@ -21,6 +21,7 @@ enum LogLevel {
 class APM {
   static var _host = ApmHostApi();
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(ApmHostApi host) {

--- a/lib/src/modules/bug_reporting.dart
+++ b/lib/src/modules/bug_reporting.dart
@@ -2,7 +2,7 @@
 
 import 'dart:async';
 
-import 'package:instabug_flutter/generated/bug_reporting.api.g.dart';
+import 'package:instabug_flutter/src/generated/bug_reporting.api.g.dart';
 import 'package:instabug_flutter/src/modules/instabug.dart';
 import 'package:instabug_flutter/src/utils/enum_converter.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
@@ -44,22 +44,28 @@ class BugReporting implements BugReportingFlutterApi {
   static OnSDKInvokeCallback? _onInvokeCallback;
   static OnSDKDismissCallback? _onDismissCallback;
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(BugReportingHostApi host) {
     _host = host;
   }
 
+  /// @nodoc
   @internal
   static void init() {
     BugReportingFlutterApi.setup(_instance);
   }
 
+  /// @nodoc
+  @internal
   @override
   void onSdkInvoke() {
     _onInvokeCallback?.call();
   }
 
+  /// @nodoc
+  @internal
   @override
   void onSdkDismiss(String dismissType, String reportType) {
     final dismissTypeKey = dismissType.toUpperCase();

--- a/lib/src/modules/crash_reporting.dart
+++ b/lib/src/modules/crash_reporting.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:instabug_flutter/generated/crash_reporting.api.g.dart';
+import 'package:instabug_flutter/src/generated/crash_reporting.api.g.dart';
 import 'package:instabug_flutter/src/models/crash_data.dart';
 import 'package:instabug_flutter/src/models/exception_data.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
@@ -14,6 +14,7 @@ class CrashReporting {
   static var _host = CrashReportingHostApi();
   static bool enabled = true;
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(CrashReportingHostApi host) {

--- a/lib/src/modules/feature_requests.dart
+++ b/lib/src/modules/feature_requests.dart
@@ -2,7 +2,7 @@
 
 import 'dart:async';
 
-import 'package:instabug_flutter/generated/feature_requests.api.g.dart';
+import 'package:instabug_flutter/src/generated/feature_requests.api.g.dart';
 import 'package:instabug_flutter/src/utils/enum_converter.dart';
 import 'package:meta/meta.dart';
 
@@ -11,6 +11,7 @@ enum ActionType { requestNewFeature, addCommentToFeature }
 class FeatureRequests {
   static var _host = FeatureRequestsHostApi();
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(FeatureRequestsHostApi host) {

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -10,8 +10,8 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:instabug_flutter/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/src/utils/enum_converter.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:meta/meta.dart';
@@ -118,12 +118,14 @@ enum ReproStepsMode { enabled, disabled, enabledWithNoScreenshots }
 class Instabug {
   static var _host = InstabugHostApi();
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(InstabugHostApi host) {
     _host = host;
   }
 
+  /// @nodoc
   @internal
   static void init() {
     BugReporting.init();

--- a/lib/src/modules/instabug_log.dart
+++ b/lib/src/modules/instabug_log.dart
@@ -2,12 +2,13 @@
 
 import 'dart:async';
 
-import 'package:instabug_flutter/generated/instabug_log.api.g.dart';
+import 'package:instabug_flutter/src/generated/instabug_log.api.g.dart';
 import 'package:meta/meta.dart';
 
 class InstabugLog {
   static var _host = InstabugLogHostApi();
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(InstabugLogHostApi host) {

--- a/lib/src/modules/network_logger.dart
+++ b/lib/src/modules/network_logger.dart
@@ -2,7 +2,7 @@
 
 import 'dart:async';
 
-import 'package:instabug_flutter/generated/instabug.api.g.dart';
+import 'package:instabug_flutter/src/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/src/models/network_data.dart';
 import 'package:instabug_flutter/src/modules/apm.dart';
 import 'package:meta/meta.dart';
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 class NetworkLogger {
   static var _host = InstabugHostApi();
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(InstabugHostApi host) {

--- a/lib/src/modules/replies.dart
+++ b/lib/src/modules/replies.dart
@@ -2,7 +2,7 @@
 
 import 'dart:async';
 
-import 'package:instabug_flutter/generated/replies.api.g.dart';
+import 'package:instabug_flutter/src/generated/replies.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:meta/meta.dart';
 
@@ -24,17 +24,21 @@ class Replies implements RepliesFlutterApi {
 
   static OnNewReplyReceivedCallback? _onNewReplyReceivedCallback;
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(RepliesHostApi host) {
     _host = host;
   }
 
+  /// @nodoc
   @internal
   static void init() {
     RepliesFlutterApi.setup(_instance);
   }
 
+  /// @nodoc
+  @internal
   @override
   void onNewReply() {
     _onNewReplyReceivedCallback?.call();

--- a/lib/src/modules/surveys.dart
+++ b/lib/src/modules/surveys.dart
@@ -2,7 +2,7 @@
 
 import 'dart:async';
 
-import 'package:instabug_flutter/generated/surveys.api.g.dart';
+import 'package:instabug_flutter/src/generated/surveys.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:meta/meta.dart';
 
@@ -26,22 +26,28 @@ class Surveys implements SurveysFlutterApi {
   static OnShowSurveyCallback? _onShowCallback;
   static OnDismissSurveyCallback? _onDismissCallback;
 
+  /// @nodoc
   @visibleForTesting
   // ignore: use_setters_to_change_properties
   static void $setHostApi(SurveysHostApi host) {
     _host = host;
   }
 
+  /// @nodoc
   @internal
   static void init() {
     SurveysFlutterApi.setup(_instance);
   }
 
+  /// @nodoc
+  @internal
   @override
   void onShowSurvey() {
     _onShowCallback?.call();
   }
 
+  /// @nodoc
+  @internal
   @override
   void onDismissSurvey() {
     _onDismissCallback?.call();

--- a/scripts/pigeon.sh
+++ b/scripts/pigeon.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DIR_DART="lib/generated"
+DIR_DART="lib/src/generated"
 DIR_IOS="ios/Classes/Generated"
 DIR_ANDROID="android/src/main/java/com/instabug/flutter/generated"
 PKG_ANDROID="com.instabug.flutter.generated"

--- a/test/apm_test.dart
+++ b/test/apm_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/apm.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/apm.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:instabug_flutter/src/utils/ibg_date_time.dart';
 import 'package:mockito/annotations.dart';

--- a/test/bug_reporting_test.dart
+++ b/test/bug_reporting_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/bug_reporting.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/bug_reporting.api.g.dart';
 import 'package:instabug_flutter/src/utils/enum_converter.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:mockito/annotations.dart';

--- a/test/crash_reporting_test.dart
+++ b/test/crash_reporting_test.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/crash_reporting.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/crash_reporting.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/test/feature_requests_test.dart
+++ b/test/feature_requests_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/feature_requests.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/feature_requests.api.g.dart';
 import 'package:instabug_flutter/src/utils/enum_converter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/test/instabug_log_test.dart
+++ b/test/instabug_log_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/instabug_log.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/instabug_log.api.g.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -2,8 +2,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/src/utils/enum_converter.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:mockito/annotations.dart';

--- a/test/network_logger_test.dart
+++ b/test/network_logger_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/apm.api.g.dart';
-import 'package:instabug_flutter/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/apm.api.g.dart';
+import 'package:instabug_flutter/src/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/test/replies_test.dart
+++ b/test/replies_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/replies.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/replies.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/test/surveys_test.dart
+++ b/test/surveys_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/surveys.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/surveys.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:instabug_flutter/generated/apm.api.g.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/apm.api.g.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 


### PR DESCRIPTION
## Description of the change

After migrating to pigeon in #279, a lot of internal APIs got exposed in the public [API Reference of v11.5.0](https://pub.dev/documentation/instabug_flutter/11.5.0/). This is fixed by:

1. Moving `generated` directory under `src`.
2. Adding `@nodoc` comments to internal methods.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
