### PR TITLE
[MOB-10972] Fix `setValueForStringWithKey` null exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Removes redundant native logs
+* Fixes a NullPointerException when overriding a string key that doesn't exist on Android 
 
 ## 11.5.0 (2022-11-24)
 

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -163,9 +163,11 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
     @Override
     public void setValueForStringWithKey(@NonNull String value, @NonNull String key) {
-        InstabugCustomTextPlaceHolder.Key resolvedKey = ArgsRegistry.placeholders.get(key);
-        placeHolder.set(resolvedKey, value);
-        Instabug.setCustomTextPlaceHolders(placeHolder);
+        if(ArgsRegistry.placeholders.containsKey(key)) {
+            InstabugCustomTextPlaceHolder.Key resolvedKey = ArgsRegistry.placeholders.get(key);
+            placeHolder.set(resolvedKey, value);
+            Instabug.setCustomTextPlaceHolders(placeHolder);
+        }
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -168,6 +168,9 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
             placeHolder.set(resolvedKey, value);
             Instabug.setCustomTextPlaceHolders(placeHolder);
         }
+        else {
+            Log.i(TAG, "Instabug: " + key +  " is only relevant to iOS.");
+        }
     }
 
     @Override

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -94,6 +94,10 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
         NSString *resolvedKey = ArgsRegistry.placeholders[key];
         [Instabug setValue:value forStringWithKey:resolvedKey];
     }
+    else {
+        NSString *logMessage = [NSString stringWithFormat: @"%@%@%@", @"Instabug: ", key,  @" is only relevant to Android."];
+        NSLog(@"%@", logMessage);
+    }
 }
 
 - (void)appendTagsTags:(NSArray<NSString *> *)tags error:(FlutterError *_Nullable *_Nonnull)error {

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -90,8 +90,10 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
 }
 
 - (void)setValueForStringWithKeyValue:(NSString *)value key:(NSString *)key error:(FlutterError *_Nullable *_Nonnull)error {
-    NSString *resolvedKey = ArgsRegistry.placeholders[key];
-    [Instabug setValue:value forStringWithKey:resolvedKey];
+    if ([ArgsRegistry.placeholders objectForKey:key]) {
+        NSString *resolvedKey = ArgsRegistry.placeholders[key];
+        [Instabug setValue:value forStringWithKey:resolvedKey];
+    }
 }
 
 - (void)appendTagsTags:(NSArray<NSString *> *)tags error:(FlutterError *_Nullable *_Nonnull)error {


### PR DESCRIPTION
## Description of the change
**Problem:**
If a certain `CustomTextPlaceHolderKey` is mapped only on iOS but not Android, and this key is passed to `setValueForStringWithKey` API, a `NullPointerException` is thrown when running the app on Android. 
**Solution:**
Add a condition to check if the `placeholders` ArgsMap contains this key before getting its value. 
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
