### PR TITLE
[MOB-11936] Add `debugLogsLevel` to `Instabug.init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Bumps Instabug Android SDK to v11.8.0
 * Bumps Instabug iOS SDK to v11.7.0
 * Deprecates `Instabug.start` in favour of the new `Instabug.init` API.
+* Deprecates `Instabug.setDebugEnabled`, `Instabug.setSdkDebugLogsLevel`, and `APM.setLogLevel` in favour of `debugLogsLevel` property, which can be passed while initializing the SDK using `Instabug.init`.
+* Deprecates the `IBGSDKDebugLogsLevel` enum in favour of the `LogLevel` enum.
+* Deprecates both `warning` and `info` values from the `LogLevel` enum.
 * Adds `hungarian` and `finnish` locales support
 * Adds missing mapping for `norwegian` and `slovak` locales on iOS
 * Exports native Android SDK

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -84,7 +84,8 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         }
     }
 
-    public void init(@NonNull String token, @NonNull List<String> invocationEvents) {
+    @Override
+    public void init(@NonNull String token, @NonNull List<String> invocationEvents, @NonNull String debugLogsLevel) {
         setCurrentPlatform();
 
         InstabugInvocationEvent[] invocationEventsArray = new InstabugInvocationEvent[invocationEvents.size()];
@@ -94,9 +95,13 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         }
 
         final Application application = (Application) context;
+        final int parsedLogLevel = ArgsRegistry.sdkLogLevels.get(debugLogsLevel);
+
         new Instabug.Builder(application, token)
                 .setInvocationEvents(invocationEventsArray)
+                .setSdkDebugLogsLevel(parsedLogLevel)
                 .build();
+
         Instabug.setScreenshotProvider(screenshotProvider);
     }
 

--- a/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
@@ -2,7 +2,7 @@ package com.instabug.flutter.util;
 
 import androidx.annotation.NonNull;
 
-import com.instabug.apm.model.LogLevel;
+import com.instabug.library.LogLevel;
 import com.instabug.bug.BugReporting;
 import com.instabug.bug.invocation.Option;
 import com.instabug.featuresrequest.ActionType;
@@ -30,13 +30,24 @@ public final class ArgsRegistry {
         }
     }
 
-    public static final ArgsMap<Integer> logLevels = new ArgsMap<Integer>() {{
+    public static final ArgsMap<Integer> sdkLogLevels = new ArgsMap<Integer>() {{
         put("LogLevel.none", LogLevel.NONE);
         put("LogLevel.error", LogLevel.ERROR);
-        put("LogLevel.warning", LogLevel.WARNING);
-        put("LogLevel.info", LogLevel.INFO);
+        put("LogLevel.warning", LogLevel.ERROR); // Deprecated
+        put("LogLevel.info", LogLevel.DEBUG); // Deprecated
         put("LogLevel.debug", LogLevel.DEBUG);
         put("LogLevel.verbose", LogLevel.VERBOSE);
+    }};
+
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated()
+    public static final ArgsMap<Integer> logLevels = new ArgsMap<Integer>() {{
+        put("LogLevel.none", com.instabug.apm.model.LogLevel.NONE);
+        put("LogLevel.error", com.instabug.apm.model.LogLevel.ERROR);
+        put("LogLevel.warning", com.instabug.apm.model.LogLevel.WARNING);
+        put("LogLevel.info", com.instabug.apm.model.LogLevel.INFO);
+        put("LogLevel.debug", com.instabug.apm.model.LogLevel.DEBUG);
+        put("LogLevel.verbose", com.instabug.apm.model.LogLevel.VERBOSE);
     }};
 
     public static ArgsMap<InstabugInvocationEvent> invocationEvents = new ArgsMap<InstabugInvocationEvent>() {{

--- a/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
@@ -2,7 +2,7 @@ package com.instabug.flutter;
 
 import static org.junit.Assert.assertTrue;
 
-import com.instabug.apm.model.LogLevel;
+import com.instabug.library.LogLevel;
 import com.instabug.bug.BugReporting;
 import com.instabug.bug.invocation.Option;
 import com.instabug.featuresrequest.ActionType;
@@ -21,16 +21,29 @@ import com.instabug.library.visualusersteps.State;
 import org.junit.Test;
 
 public class ArgsRegistryTest {
+    @Test
+    public void testSdkLogLevels() {
+        Integer[] values = {
+                LogLevel.NONE,
+                LogLevel.ERROR,
+                LogLevel.DEBUG,
+                LogLevel.VERBOSE,
+        };
+
+        for (Integer value : values) {
+            assertTrue(ArgsRegistry.sdkLogLevels.containsValue(value));
+        }
+    }
 
     @Test
     public void testLogLevels() {
         Integer[] values = {
-                LogLevel.NONE,
-                LogLevel.ERROR,
-                LogLevel.WARNING,
-                LogLevel.INFO,
-                LogLevel.DEBUG,
-                LogLevel.VERBOSE,
+                com.instabug.apm.model.LogLevel.NONE,
+                com.instabug.apm.model.LogLevel.ERROR,
+                com.instabug.apm.model.LogLevel.WARNING,
+                com.instabug.apm.model.LogLevel.INFO,
+                com.instabug.apm.model.LogLevel.DEBUG,
+                com.instabug.apm.model.LogLevel.VERBOSE,
         };
 
         for (Integer value : values) {

--- a/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
+++ b/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
@@ -101,7 +101,7 @@ public class InstabugApiTest {
     }
 
     @Test
-    public void testInit() {
+    public void testSdkInit() {
         String token = "app-token";
         List<String> invocationEvents = Collections.singletonList("InvocationEvent.floatingButton");
         String logLevel = "LogLevel.error";

--- a/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
+++ b/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
@@ -111,6 +111,7 @@ public class InstabugApiTest {
             // Initializes Instabug with the correct token
             assertEquals(token, actualToken);
             when(mock.setInvocationEvents(any())).thenReturn(mock);
+            when(mock.setSdkDebugLogsLevel(anyInt())).thenReturn(mock);
         });
 
         api.init(token, invocationEvents, logLevel);

--- a/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
+++ b/android/src/test/java/com/instabug/flutter/InstabugApiTest.java
@@ -30,6 +30,7 @@ import com.instabug.library.Feature;
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder;
+import com.instabug.library.LogLevel;
 import com.instabug.library.Platform;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.model.NetworkLog;
@@ -100,9 +101,10 @@ public class InstabugApiTest {
     }
 
     @Test
-    public void testStart() {
+    public void testInit() {
         String token = "app-token";
         List<String> invocationEvents = Collections.singletonList("InvocationEvent.floatingButton");
+        String logLevel = "LogLevel.error";
 
         MockedConstruction<Instabug.Builder> mInstabugBuilder = mockConstruction(Instabug.Builder.class, (mock, context) -> {
             String actualToken = (String) context.arguments().get(1);
@@ -111,7 +113,7 @@ public class InstabugApiTest {
             when(mock.setInvocationEvents(any())).thenReturn(mock);
         });
 
-        api.init(token, invocationEvents);
+        api.init(token, invocationEvents, logLevel);
 
         Instabug.Builder builder = mInstabugBuilder.constructed().get(0);
 
@@ -122,6 +124,7 @@ public class InstabugApiTest {
                 mInstabugBuilder.constructed().size()
         );
         verify(builder).setInvocationEvents(InstabugInvocationEvent.FLOATING_BUTTON);
+        verify(builder).setSdkDebugLogsLevel(LogLevel.ERROR);
         verify(builder).build();
 
         // Sets screenshot provider

--- a/example/ios/InstabugSampleTests/InstabugApiTests.m
+++ b/example/ios/InstabugSampleTests/InstabugApiTests.m
@@ -34,15 +34,16 @@
     OCMVerify([self.mInstabug setEnabled:YES]);
 }
 
-- (void)testStart {
+- (void)testInit {
     NSString *token = @"app-token";
     NSArray<NSString *> *invocationEvents = @[@"InvocationEvent.floatingButton", @"InvocationEvent.screenshot"];
+    NSString *logLevel = @"LogLevel.error";
     FlutterError *error;
     
-    [self.api initToken:token invocationEvents:invocationEvents error:&error];
+    [self.api initToken:token invocationEvents:invocationEvents debugLogsLevel:logLevel error:&error];
 
     OCMVerify([self.mInstabug setCurrentPlatform:IBGPlatformFlutter]);
-    
+    OCMVerify([self.mInstabug setSdkDebugLogsLevel:IBGSDKDebugLogsLevelError]);
     OCMVerify([self.mInstabug startWithToken:token invocationEvents:(IBGInvocationEventFloatingButton | IBGInvocationEventScreenshot)]);
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ void main() {
   Instabug.init(
     token: 'ed6f659591566da19b67857e1b9d40ab',
     invocationEvents: [InvocationEvent.floatingButton],
+    debugLogsLevel: LogLevel.verbose,
   );
 
   Instabug.setWelcomeMessageMode(WelcomeMessageMode.disabled);

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -18,7 +18,7 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
     Instabug.enabled = [isEnabled boolValue];
 }
 
-- (void)initToken:(NSString *)token invocationEvents:(NSArray<NSString *> *)invocationEvents error:(FlutterError *_Nullable *_Nonnull)error {
+- (void)initToken:(NSString *)token invocationEvents:(NSArray<NSString *> *)invocationEvents debugLogsLevel:(NSString *)debugLogsLevel error:(FlutterError *_Nullable *_Nonnull)error {
     SEL setPrivateApiSEL = NSSelectorFromString(@"setCurrentPlatform:");
     if ([[Instabug class] respondsToSelector:setPrivateApiSEL]) {
         NSInteger *platformID = IBGPlatformFlutter;
@@ -35,6 +35,9 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
         resolvedEvents |= (ArgsRegistry.invocationEvents[event]).integerValue;
     }
 
+    IBGSDKDebugLogsLevel resolvedLogLevel = (ArgsRegistry.sdkLogLevels[debugLogsLevel]).integerValue;
+
+    [Instabug setSdkDebugLogsLevel:resolvedLogLevel];
     [Instabug startWithToken:token invocationEvents:resolvedEvents];
 }
 

--- a/ios/Classes/Util/ArgsRegistry.h
+++ b/ios/Classes/Util/ArgsRegistry.h
@@ -6,7 +6,7 @@ typedef NSDictionary<NSString *, NSNumber *> ArgsDictionary;
 @interface ArgsRegistry : NSObject
 
 + (ArgsDictionary *)sdkLogLevels;
-+ (ArgsDictionary *)logLevels;
++ (ArgsDictionary *)logLevels __deprecated_msg("Use sdkLogLevels instead.");
 + (ArgsDictionary *)invocationEvents;
 + (ArgsDictionary *)invocationOptions;
 + (ArgsDictionary *)colorThemes;

--- a/ios/Classes/Util/ArgsRegistry.m
+++ b/ios/Classes/Util/ArgsRegistry.m
@@ -4,10 +4,17 @@
 
 + (ArgsDictionary *)sdkLogLevels {
     return @{
-        @"IBGSDKDebugLogsLevel.verbose" : @(IBGSDKDebugLogsLevelVerbose),
-        @"IBGSDKDebugLogsLevel.debug" : @(IBGSDKDebugLogsLevelDebug),
-        @"IBGSDKDebugLogsLevel.error" : @(IBGSDKDebugLogsLevelError),
-        @"IBGSDKDebugLogsLevel.none" : @(IBGSDKDebugLogsLevelNone),
+        @"LogLevel.none" : @(IBGLogLevelNone),
+        @"LogLevel.error" : @(IBGSDKDebugLogsLevelError),
+        @"LogLevel.warning" : @(IBGSDKDebugLogsLevelError), // Deprecated
+        @"LogLevel.info" : @(IBGSDKDebugLogsLevelDebug), // Deprecated
+        @"LogLevel.debug" : @(IBGSDKDebugLogsLevelDebug),
+        @"LogLevel.verbose" : @(IBGSDKDebugLogsLevelVerbose),
+
+        @"IBGSDKDebugLogsLevel.verbose" : @(IBGSDKDebugLogsLevelVerbose), // Deprecated
+        @"IBGSDKDebugLogsLevel.debug" : @(IBGSDKDebugLogsLevelDebug), // Deprecated
+        @"IBGSDKDebugLogsLevel.error" : @(IBGSDKDebugLogsLevelError), // Deprecated
+        @"IBGSDKDebugLogsLevel.none" : @(IBGSDKDebugLogsLevelNone), // Deprecated
     };
 }
 

--- a/lib/src/modules/apm.dart
+++ b/lib/src/modules/apm.dart
@@ -5,18 +5,10 @@ import 'dart:async';
 import 'package:instabug_flutter/src/generated/apm.api.g.dart';
 import 'package:instabug_flutter/src/models/network_data.dart';
 import 'package:instabug_flutter/src/models/trace.dart';
+import 'package:instabug_flutter/src/modules/instabug.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
 import 'package:instabug_flutter/src/utils/ibg_date_time.dart';
 import 'package:meta/meta.dart';
-
-enum LogLevel {
-  none,
-  error,
-  warning,
-  info,
-  debug,
-  verbose,
-}
 
 class APM {
   static var _host = ApmHostApi();
@@ -36,6 +28,7 @@ class APM {
 
   /// Sets log Level to determine level of details in a log
   /// [logLevel] Enum value to determine the level
+  @Deprecated("Use [Instabug.init]'s [debugLogsLevel] parameter instead.")
   static Future<void> setLogLevel(LogLevel logLevel) async {
     return _host.setLogLevel(logLevel.toString());
   }

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -55,6 +55,18 @@ enum IBGLocale {
   turkish,
 }
 
+enum LogLevel {
+  none,
+  error,
+  @Deprecated('Use [LogLevel.error] instead.')
+  warning,
+  @Deprecated('Use [LogLevel.debug] instead.')
+  info,
+  debug,
+  verbose,
+}
+
+@Deprecated("Use [LogLevel] instead.")
 enum IBGSDKDebugLogsLevel { verbose, debug, error, none }
 
 enum ColorTheme { dark, light }
@@ -151,16 +163,20 @@ class Instabug {
   /// Starts the SDK.
   /// This is the main SDK method that does all the magic. This is the only
   /// method that SHOULD be called.
-  /// The [token] that identifies the app, you can find
-  /// it on your dashboard.
-  /// The [invocationEvents] are the events that invoke
-  /// the SDK's UI.
+  /// The [token] that identifies the app, you can find it on your dashboard.
+  /// The [invocationEvents] are the events that invoke the SDK's UI.
+  /// The [debugLogsLevel] used to debug Instabug's SDK.
   static Future<void> init({
     required String token,
     required List<InvocationEvent> invocationEvents,
+    LogLevel debugLogsLevel = LogLevel.error,
   }) async {
     $setup();
-    return _host.init(token, invocationEvents.mapToString());
+    return _host.init(
+      token,
+      invocationEvents.mapToString(),
+      debugLogsLevel.toString(),
+    );
   }
 
   @Deprecated(
@@ -206,8 +222,9 @@ class Instabug {
     return _host.setLocale(locale.toString());
   }
 
-  /// Sets the verbosity level of logs used to debug The SDK. The defualt value in debug
+  /// Sets the verbosity level of logs used to debug The SDK. The default value in debug
   /// mode is sdkDebugLogsLevelVerbose and in production is sdkDebugLogsLevelError.
+  @Deprecated("Use [Instabug.init]'s [debugLogsLevel] parameter instead.")
   static Future<void> setSdkDebugLogsLevel(
     IBGSDKDebugLogsLevel sdkDebugLogsLevel,
   ) async {
@@ -306,6 +323,7 @@ class Instabug {
   /// Android only
   /// Enable/disable SDK logs
   /// [debugEnabled] desired state of debug mode.
+  @Deprecated("Use [Instabug.init]'s [debugLogsLevel] parameter instead.")
   static Future<void> setDebugEnabled(bool debugEnabled) async {
     if (IBGBuildInfo.instance.isAndroid) {
       return _host.setDebugEnabled(debugEnabled);

--- a/pigeons/instabug.api.dart
+++ b/pigeons/instabug.api.dart
@@ -3,7 +3,7 @@ import 'package:pigeon/pigeon.dart';
 @HostApi()
 abstract class InstabugHostApi {
   void setEnabled(bool isEnabled);
-  void init(String token, List<String> invocationEvents);
+  void init(String token, List<String> invocationEvents, String debugLogsLevel);
 
   void show();
   void showWelcomeMessageWithMode(String mode);

--- a/test/apm_test.dart
+++ b/test/apm_test.dart
@@ -61,6 +61,7 @@ void main() {
   test('[setLogLevel] should call host method', () async {
     const level = LogLevel.debug;
 
+    // ignore: deprecated_member_use_from_same_package
     await APM.setLogLevel(level);
 
     verify(

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -277,6 +277,7 @@ void main() {
     const enabled = true;
     when(mBuildInfo.isAndroid).thenReturn(true);
 
+    // ignore: deprecated_member_use_from_same_package
     await Instabug.setDebugEnabled(enabled);
 
     verify(
@@ -285,8 +286,10 @@ void main() {
   });
 
   test('[setSdkDebugLogsLevel] should call host method', () async {
+    // ignore: deprecated_member_use_from_same_package
     const level = IBGSDKDebugLogsLevel.error;
 
+    // ignore: deprecated_member_use_from_same_package
     await Instabug.setSdkDebugLogsLevel(level);
 
     verify(

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -47,7 +47,7 @@ void main() {
     );
 
     verify(
-      mHost.init(token, events.mapToString()),
+      mHost.init(token, events.mapToString(), LogLevel.error.toString()),
     ).called(1);
   });
 


### PR DESCRIPTION
## Description of the change

A new way to enable SDK debug logs, using the newly added `Instabug.init` API, that works on all platform and for all modules.

### Old Way (Deprecated)

```dart
Instabug.setDebugEnabled(true); // Android only
Instabug.setSdkDebugLogsLevel(IBGSDKDebugLogsLevel.error); // iOS only
APM.setLogLevel(LogLevel.error); // APM only
```

### New Way

```dart
Instabug.init({
  // ...
  debugLogsLevel: LogLevel.error,
});
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
