### PR TITLE
[MOB-12236] Bump iOS SDK to `v11.10.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Bumps Instabug Android SDK to v11.11.0.
+* Bumps Instabug iOS SDK to v11.10.0.
 
 ## 11.9.0 (2023-02-21)
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (11.9.0)
+  - Instabug (11.10.0)
   - instabug_flutter (11.9.0):
     - Flutter
-    - Instabug (= 11.9.0)
+    - Instabug (= 11.10.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Instabug: 1d21096fdadbc1f26cd2fc2322ff8e060a611237
-  instabug_flutter: 40394da80e1cf39b540a3836caf4c555739b01de
+  Instabug: 5b4694c5628a440fd52e047512502a0645e94985
+  instabug_flutter: fd256ed2c7c23dd98ba176829e6a710cf148460a
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 637e800c0a0982493b68adb612d2dd60c15c8e5c

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '11.9.0'
+  s.dependency 'Instabug', '11.10.0'
 end
 


### PR DESCRIPTION
## Description of the change

- Bump iOS SDK to v11.10.0

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
