### PR TITLE
[MOB-12241] Bump iOS SDK to `v11.10.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v11.10.0...dev)
+
+### Changed
+
+- Bump Instabug iOS SDK to v11.10.1 ([#358](https://github.com/Instabug/Instabug-Flutter/pull/358)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.1).
+
 ## [11.10.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.9.0...v11.10.0) (April 12, 2023)
 
 ### Changed

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (11.10.0)
+  - Instabug (11.10.1)
   - instabug_flutter (11.10.0):
     - Flutter
-    - Instabug (= 11.10.0)
+    - Instabug (= 11.10.1)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Instabug: 5b4694c5628a440fd52e047512502a0645e94985
-  instabug_flutter: aa898c666f3fca54467efb80a1217004bc9202b8
+  Instabug: 8b0fcb6dd1bb91ae30a80176431d3e7f57ec3c4f
+  instabug_flutter: 328aa7af20d6d8677ffde688f7eaf407208be2e0
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 637e800c0a0982493b68adb612d2dd60c15c8e5c

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '11.10.0'
+  s.dependency 'Instabug', '11.10.1'
 end
 


### PR DESCRIPTION
## Description of the change

- Bump iOS SDK to v11.10.1

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
