### PR TITLE
[MOB-12372] Migrate Flutter Formatting to Dart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
       - run: flutter pub get
       - run:
           name: Check Format
-          command: flutter format . --set-exit-if-changed
+          command: dart format . --set-exit-if-changed
 
   lint_flutter:
     docker:

--- a/scripts/pigeon.sh
+++ b/scripts/pigeon.sh
@@ -26,7 +26,7 @@ generate_pigeon() {
 
   # Generated files are not formatted by default,
   # this affects pacakge score.
-  flutter format "$DIR_DART/$name_snake.api.g.dart"
+  dart format "$DIR_DART/$name_snake.api.g.dart"
 }
 
 for file in pigeons/**


### PR DESCRIPTION
## Description of the change

### Problem
The `flutter format` command has been deprecated in favor of `dart format`.

### Solution
Change `flutter format` to `dart format`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
