### PR TITLE
[INSD-9704] Fix The `onInvoke` Callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v11.12.0...dev)
+
+### Fixed
+
+- Fix an issue with the `onInvoke` callback not being called and causing `Instabug.show` to break on Android ([#369](https://github.com/Instabug/Instabug-Flutter/pull/369)).
+
 ## [11.12.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.10.1...v11.12.0) (May 30, 2023)
 
 ### Changed

--- a/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import com.instabug.bug.BugReporting;
 import com.instabug.flutter.generated.BugReportingPigeon;
 import com.instabug.flutter.util.ArgsRegistry;
+import com.instabug.flutter.util.ThreadManager;
 import com.instabug.library.Feature;
 import com.instabug.library.OnSdkDismissCallback;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
@@ -132,9 +133,17 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
         BugReporting.setOnInvokeCallback(new OnInvokeCallback() {
             @Override
             public void onInvoke() {
-                flutterApi.onSdkInvoke(new BugReportingPigeon.BugReportingFlutterApi.Reply<Void>() {
+                // The on invoke callback for Flutter needs to be run on the
+                // main thread, otherwise, it won't work and will break the
+                // Instabug.show API
+                ThreadManager.runOnMainThread(new Runnable() {
                     @Override
-                    public void reply(Void reply) {
+                    public void run() {
+                        flutterApi.onSdkInvoke(new BugReportingPigeon.BugReportingFlutterApi.Reply<Void>() {
+                            @Override
+                            public void reply(Void reply) {
+                            }
+                        });
                     }
                 });
             }

--- a/android/src/main/java/com/instabug/flutter/util/ThreadManager.java
+++ b/android/src/main/java/com/instabug/flutter/util/ThreadManager.java
@@ -1,10 +1,16 @@
 package com.instabug.flutter.util;
 
 import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Looper;
 
 public class ThreadManager {
     // TODO: migrate to Flutter's TaskQueue
     public static void runOnBackground(Runnable runnable) {
         AsyncTask.execute(runnable);
+    }
+
+    public static void runOnMainThread(Runnable runnable) {
+        new Handler(Looper.getMainLooper()).post(runnable);
     }
 }


### PR DESCRIPTION
## Description of the change

The `BugReporting.setOnInvokeCallback` API breaks the `Instabug.show` API because the on-invoke doesn't get called on the main thread which causes the native Android SDK to produce the following error:

```
E/IBG-Core(22608): Instabug failed to execute {Instabug.show} due toMethods marked with @UiThread must be executed on the main thread. Current thread: IBG-API-executor-0
```

This PR fixes this issue by running the on-invoke callback for Flutter on the main thread.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
