### PR TITLE
[INSD-9768] Fix Channel Method Calls on Background Threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@
 
 ### Fixed
 
-- Fix an issue with the `onInvoke` callback not being called and causing `Instabug.show` to break on Android ([#369](https://github.com/Instabug/Instabug-Flutter/pull/369)).
+- Fix an issue that caused APIs that return a value or invoke a callback break on Android in some versions of Flutter ([#370](https://github.com/Instabug/Instabug-Flutter/pull/370), [#369](https://github.com/Instabug/Instabug-Flutter/pull/369)).
+  
+  Below is a list of all the affected APIs:
+  
+  - `APM.startExecutionTrace`
+  - `BugReporting.setOnInvokeCallback`
+  - `BugReporting.setOnDismissCallback`
+  - `Instabug.getTags`
+  - `Instabug.getUserAttributeForKey`
+  - `Instabug.getUserAttributes`
+  - `Replies.getUnreadRepliesCount`
+  - `Replies.hasChats`
+  - `Replies.setOnNewReplyReceivedCallback`
+  - `Surveys.hasRespondToSurvey`
+  - `Surveys.setOnShowCallback`
+  - `Surveys.setOnDismissCallback`
 
 ## [11.12.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.10.1...v11.12.0) (May 30, 2023)
 

--- a/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
@@ -76,13 +76,30 @@ public class ApmApi implements ApmPigeon.ApmHostApi {
                             ExecutionTrace trace = APM.startExecutionTrace(name);
                             if (trace != null) {
                                 traces.put(id, trace);
-                                result.success(id);
+
+                                ThreadManager.runOnMainThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        result.success(id);
+                                    }
+                                });
                             } else {
-                                result.success(null);
+                                ThreadManager.runOnMainThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        result.success(null);
+                                    }
+                                });
                             }
                         } catch (Exception e) {
                             e.printStackTrace();
-                            result.success(null);
+
+                            ThreadManager.runOnMainThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    result.success(null);
+                                }
+                            });
                         }
                     }
                 }

--- a/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/BugReportingApi.java
@@ -155,9 +155,14 @@ public class BugReportingApi implements BugReportingPigeon.BugReportingHostApi {
         BugReporting.setOnDismissCallback(new OnSdkDismissCallback() {
             @Override
             public void call(DismissType dismissType, ReportType reportType) {
-                flutterApi.onSdkDismiss(dismissType.toString(), reportType.toString(), new BugReportingPigeon.BugReportingFlutterApi.Reply<Void>() {
+                ThreadManager.runOnMainThread(new Runnable() {
                     @Override
-                    public void reply(Void reply) {
+                    public void run() {
+                        flutterApi.onSdkDismiss(dismissType.toString(), reportType.toString(), new BugReportingPigeon.BugReportingFlutterApi.Reply<Void>() {
+                            @Override
+                            public void reply(Void reply) {
+                            }
+                        });
                     }
                 });
             }

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -196,7 +196,14 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
                 new Runnable() {
                     @Override
                     public void run() {
-                        result.success(Instabug.getTags());
+                        final List<String> tags = Instabug.getTags();
+
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                result.success(tags);
+                            }
+                        });
                     }
                 }
         );
@@ -234,7 +241,14 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
                 new Runnable() {
                     @Override
                     public void run() {
-                        result.success(Instabug.getUserAttribute(key));
+                        final String attribute = Instabug.getUserAttribute(key);
+
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                result.success(attribute);
+                            }
+                        });
                     }
                 }
         );
@@ -246,7 +260,14 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
                 new Runnable() {
                     @Override
                     public void run() {
-                        result.success(Instabug.getAllUserAttributes());
+                        final Map<String, String> attributes = Instabug.getAllUserAttributes();
+
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                result.success(attributes);
+                            }
+                        });
                     }
                 }
         );

--- a/android/src/main/java/com/instabug/flutter/modules/RepliesApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/RepliesApi.java
@@ -52,7 +52,14 @@ public class RepliesApi implements RepliesPigeon.RepliesHostApi {
                 new Runnable() {
                     @Override
                     public void run() {
-                        result.success((long) Replies.getUnreadRepliesCount());
+                        final long count = Replies.getUnreadRepliesCount();
+
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                result.success(count);
+                            }
+                        });
                     }
                 }
         );
@@ -64,7 +71,14 @@ public class RepliesApi implements RepliesPigeon.RepliesHostApi {
                 new Runnable() {
                     @Override
                     public void run() {
-                        result.success(Replies.hasChats());
+                        final boolean hasChats = Replies.hasChats();
+
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                result.success(hasChats);
+                            }
+                        });
                     }
                 }
         );
@@ -75,9 +89,14 @@ public class RepliesApi implements RepliesPigeon.RepliesHostApi {
         Replies.setOnNewReplyReceivedCallback(new Runnable() {
             @Override
             public void run() {
-                flutterApi.onNewReply(new RepliesPigeon.RepliesFlutterApi.Reply<Void>() {
+                ThreadManager.runOnMainThread(new Runnable() {
                     @Override
-                    public void reply(Void reply) {
+                    public void run() {
+                        flutterApi.onNewReply(new RepliesPigeon.RepliesFlutterApi.Reply<Void>() {
+                            @Override
+                            public void reply(Void reply) {
+                            }
+                        });
                     }
                 });
             }

--- a/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
@@ -69,7 +69,13 @@ public class SurveysApi implements SurveysPigeon.SurveysHostApi {
                     @Override
                     public void run() {
                         final boolean hasResponded = Surveys.hasRespondToSurvey(surveyToken);
-                        result.success(hasResponded);
+
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                result.success(hasResponded);
+                            }
+                        });
                     }
                 }
         );
@@ -88,7 +94,12 @@ public class SurveysApi implements SurveysPigeon.SurveysHostApi {
                             titles.add(survey.getTitle());
                         }
 
-                        result.success(titles);
+                        ThreadManager.runOnMainThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                result.success(titles);
+                            }
+                        });
                     }
                 }
         );
@@ -99,9 +110,14 @@ public class SurveysApi implements SurveysPigeon.SurveysHostApi {
         Surveys.setOnShowCallback(new OnShowCallback() {
             @Override
             public void onShow() {
-                flutterApi.onShowSurvey(new SurveysPigeon.SurveysFlutterApi.Reply<Void>() {
+                ThreadManager.runOnMainThread(new Runnable() {
                     @Override
-                    public void reply(Void reply) {
+                    public void run() {
+                        flutterApi.onShowSurvey(new SurveysPigeon.SurveysFlutterApi.Reply<Void>() {
+                            @Override
+                            public void reply(Void reply) {
+                            }
+                        });
                     }
                 });
             }
@@ -113,9 +129,14 @@ public class SurveysApi implements SurveysPigeon.SurveysHostApi {
         Surveys.setOnDismissCallback(new OnDismissCallback() {
             @Override
             public void onDismiss() {
-                flutterApi.onDismissSurvey(new SurveysPigeon.SurveysFlutterApi.Reply<Void>() {
+                ThreadManager.runOnMainThread(new Runnable() {
                     @Override
-                    public void reply(Void reply) {
+                    public void run() {
+                        flutterApi.onDismissSurvey(new SurveysPigeon.SurveysFlutterApi.Reply<Void>() {
+                            @Override
+                            public void reply(Void reply) {
+                            }
+                        });
                     }
                 });
             }

--- a/android/src/test/java/com/instabug/flutter/util/GlobalMocks.java
+++ b/android/src/test/java/com/instabug/flutter/util/GlobalMocks.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import org.json.JSONObject;
 import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.lang.reflect.Method;
 
@@ -26,13 +27,17 @@ public class GlobalMocks {
 
         // ThreadManager mock
         threadManager = mockStatic(ThreadManager.class);
+        Answer threadAnswer = (InvocationOnMock invocation) -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        };
         threadManager
                 .when(() -> ThreadManager.runOnBackground(any(Runnable.class)))
-                .thenAnswer((InvocationOnMock invocation) -> {
-                    Runnable runnable = invocation.getArgument(0);
-                    runnable.run();
-                    return null;
-                });
+                .thenAnswer(threadAnswer);
+        threadManager
+                .when(() -> ThreadManager.runOnMainThread(any(Runnable.class)))
+                .thenAnswer(threadAnswer);
 
         // Reflection mock
         reflection = mockStatic(Reflection.class);


### PR DESCRIPTION
## Description of the change

### Problem

As stated in the [Flutter docs](https://docs.flutter.dev/platform-integration/platform-channels?tab=type-mappings-kotlin-tab#jumping-to-the-ui-thread-in-android)

> To comply with channels’ UI thread requirement, you might need to jump from a background thread to Android’s UI thread to execute a channel method.

We have some APIs that run on a background thread either explicitly by using `ThreadManager.runOnBackground` or are implicitly called on a background thread by the native Android SDK.

This is the same issue we fixed in #369 for the `onInvoke` callback but applied to all the remaining APIs.

### Solution

In order to fix this issue, all channel method calls (e.g. sending results, invoking callbacks) have been wrapped with `ThreadManager.runOnMainThread`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
