### PR TITLE
feat: support network logs obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v11.14.0...dev)
 
+### Added
+
+- Add network logs obfuscation support using the new `NetworkLogger.obfuscateLog` API ([#380](https://github.com/Instabug/Instabug-Flutter/pull/380)).
+
 ### Changed
 
 - Bump Instabug iOS SDK to v11.14.0 ([#383](https://github.com/Instabug/Instabug-Flutter/pull/383)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.14.0).

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -2,6 +2,7 @@
 #import <CoreText/CoreText.h>
 #import <Flutter/Flutter.h>
 #import "Instabug.h"
+#import "IBGNetworkLogger+CP.h"
 #import "InstabugApi.h"
 #import "ArgsRegistry.h"
 
@@ -28,6 +29,10 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
         [inv setArgument:&(platformID) atIndex:2];
         [inv invoke];
     }
+    
+    // Disable automatic capturing of native iOS network logs to avoid duplicate
+    // logs of the same request when using a native network client like cupertino_http
+    [IBGNetworkLogger disableAutomaticCapturingOfNetworkLogs];
 
     IBGInvocationEvent resolvedEvents = 0;
 

--- a/ios/Classes/Util/IBGNetworkLogger+CP.h
+++ b/ios/Classes/Util/IBGNetworkLogger+CP.h
@@ -1,0 +1,11 @@
+#import <Instabug/Instabug.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface IBGNetworkLogger (CP)
+
++ (void)disableAutomaticCapturingOfNetworkLogs;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/lib/src/modules/network_logger.dart
+++ b/lib/src/modules/network_logger.dart
@@ -2,13 +2,15 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:instabug_flutter/src/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/src/models/network_data.dart';
 import 'package:instabug_flutter/src/modules/apm.dart';
-import 'package:meta/meta.dart';
+import 'package:instabug_flutter/src/utils/network_manager.dart';
 
 class NetworkLogger {
   static var _host = InstabugHostApi();
+  static var _manager = NetworkManager();
 
   /// @nodoc
   @visibleForTesting
@@ -17,8 +19,21 @@ class NetworkLogger {
     _host = host;
   }
 
+  /// @nodoc
+  @visibleForTesting
+  // ignore: use_setters_to_change_properties
+  static void $setManager(NetworkManager manager) {
+    _manager = manager;
+  }
+
+  static void obfuscateLog(ObfuscateLogCallback callback) {
+    _manager.setObfuscateLogCallback(callback);
+  }
+
   Future<void> networkLog(NetworkData data) async {
-    await _host.networkLog(data.toJson());
-    await APM.networkLogAndroid(data);
+    final obfuscated = await _manager.obfuscateLog(data);
+
+    await _host.networkLog(obfuscated.toJson());
+    await APM.networkLogAndroid(obfuscated);
   }
 }

--- a/lib/src/modules/network_logger.dart
+++ b/lib/src/modules/network_logger.dart
@@ -26,6 +26,19 @@ class NetworkLogger {
     _manager = manager;
   }
 
+  /// Registers a callback to selectively obfuscate network log data.
+  ///
+  /// The [callback] function takes a [NetworkData] object as its argument and
+  /// should return a modified [NetworkData] object with sensitive information
+  /// obfuscated.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// NetworkLogger.obfuscateLog((data) {
+  ///   // Modify 'data' as needed and return it.
+  /// });
+  /// ```
   static void obfuscateLog(ObfuscateLogCallback callback) {
     _manager.setObfuscateLogCallback(callback);
   }

--- a/lib/src/utils/network_manager.dart
+++ b/lib/src/utils/network_manager.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+import 'package:instabug_flutter/instabug_flutter.dart';
+
+typedef ObfuscateLogCallback = FutureOr<NetworkData> Function(NetworkData data);
+
+/// Mockable [NetworkManager] responsible for processing network logs
+/// before they are sent to the native SDKs.
+class NetworkManager {
+  ObfuscateLogCallback? _obfuscateLogCallback;
+
+  // ignore: use_setters_to_change_properties
+  void setObfuscateLogCallback(ObfuscateLogCallback callback) {
+    _obfuscateLogCallback = callback;
+  }
+
+  FutureOr<NetworkData> obfuscateLog(NetworkData data) {
+    if (_obfuscateLogCallback == null) {
+      return data;
+    }
+
+    return _obfuscateLogCallback!(data);
+  }
+}

--- a/lib/src/utils/network_manager.dart
+++ b/lib/src/utils/network_manager.dart
@@ -14,24 +14,6 @@ class NetworkManager {
     _obfuscateLogCallback = callback;
   }
 
-  /// Registers a callback to selectively obfuscate network log data.
-  ///
-  /// Use this method to set a callback function that determines whether
-  /// specific network log data should undergo obfuscation before being recorded
-  /// or logged.
-  ///
-  /// The [callback] function takes a [NetworkData] object as its argument and
-  /// should return a modified [NetworkData] object with sensitive information
-  /// obfuscated.
-  ///
-  /// Example:
-  ///
-  /// ```dart
-  /// NetworkLogger.obfuscateLog((data) {
-  ///   // Implement custom logic to obfuscate sensitive data here.
-  ///   // Modify 'data' as needed and return it.
-  /// });
-  /// ```
   FutureOr<NetworkData> obfuscateLog(NetworkData data) {
     if (_obfuscateLogCallback == null) {
       return data;

--- a/lib/src/utils/network_manager.dart
+++ b/lib/src/utils/network_manager.dart
@@ -14,6 +14,24 @@ class NetworkManager {
     _obfuscateLogCallback = callback;
   }
 
+  /// Registers a callback to selectively obfuscate network log data.
+  ///
+  /// Use this method to set a callback function that determines whether
+  /// specific network log data should undergo obfuscation before being recorded
+  /// or logged.
+  ///
+  /// The [callback] function takes a [NetworkData] object as its argument and
+  /// should return a modified [NetworkData] object with sensitive information
+  /// obfuscated.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// NetworkLogger.obfuscateLog((data) {
+  ///   // Implement custom logic to obfuscate sensitive data here.
+  ///   // Modify 'data' as needed and return it.
+  /// });
+  /// ```
   FutureOr<NetworkData> obfuscateLog(NetworkData data) {
     if (_obfuscateLogCallback == null) {
       return data;

--- a/test/network_logger_test.dart
+++ b/test/network_logger_test.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
 import 'package:instabug_flutter/src/generated/apm.api.g.dart';
 import 'package:instabug_flutter/src/generated/instabug.api.g.dart';
 import 'package:instabug_flutter/src/utils/ibg_build_info.dart';
+import 'package:instabug_flutter/src/utils/network_manager.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
@@ -13,6 +16,7 @@ import 'network_logger_test.mocks.dart';
   ApmHostApi,
   InstabugHostApi,
   IBGBuildInfo,
+  NetworkManager,
 ])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -21,6 +25,7 @@ void main() {
   final mApmHost = MockApmHostApi();
   final mInstabugHost = MockInstabugHostApi();
   final mBuildInfo = MockIBGBuildInfo();
+  final mManager = MockNetworkManager();
 
   final logger = NetworkLogger();
   final data = NetworkData(
@@ -32,11 +37,20 @@ void main() {
   setUpAll(() {
     APM.$setHostApi(mApmHost);
     NetworkLogger.$setHostApi(mInstabugHost);
+    NetworkLogger.$setManager(mManager);
     IBGBuildInfo.setInstance(mBuildInfo);
+  });
+
+  setUp(() {
+    reset(mApmHost);
+    reset(mInstabugHost);
+    reset(mBuildInfo);
+    reset(mManager);
   });
 
   test('[networkLog] should call 1 host method on iOS', () async {
     when(mBuildInfo.isAndroid).thenReturn(false);
+    when(mManager.obfuscateLog(data)).thenReturn(data);
 
     await logger.networkLog(data);
 
@@ -51,6 +65,7 @@ void main() {
 
   test('[networkLog] should call 2 host methods on Android', () async {
     when(mBuildInfo.isAndroid).thenReturn(true);
+    when(mManager.obfuscateLog(data)).thenReturn(data);
 
     await logger.networkLog(data);
 
@@ -60,6 +75,37 @@ void main() {
 
     verify(
       mApmHost.networkLogAndroid(data.toJson()),
+    ).called(1);
+  });
+
+  test('[networkLog] should obfuscate network data before logging', () async {
+    final obfuscated = data.copyWith(requestBody: 'obfuscated');
+
+    when(mBuildInfo.isAndroid).thenReturn(true);
+    when(mManager.obfuscateLog(data)).thenReturn(obfuscated);
+
+    await logger.networkLog(data);
+
+    verify(
+      mManager.obfuscateLog(data),
+    ).called(1);
+
+    verify(
+      mInstabugHost.networkLog(obfuscated.toJson()),
+    ).called(1);
+
+    verify(
+      mApmHost.networkLogAndroid(obfuscated.toJson()),
+    ).called(1);
+  });
+
+  test('[obfuscateLog] should set obfuscation callback on manager', () async {
+    FutureOr<NetworkData> callback(NetworkData data) => data;
+
+    NetworkLogger.obfuscateLog(callback);
+
+    verify(
+      mManager.setObfuscateLogCallback(callback),
     ).called(1);
   });
 }

--- a/test/network_manager_test.dart
+++ b/test/network_manager_test.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/utils/network_manager.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final data = NetworkData(
+    url: "https://httpbin.org/get",
+    method: "GET",
+    startTime: DateTime.now(),
+  );
+  late NetworkManager manager;
+
+  setUp(() {
+    manager = NetworkManager();
+  });
+
+  test('[obfuscateLog] should return same data when obfuscate log callback',
+      () async {
+    final result = await manager.obfuscateLog(data);
+
+    expect(result, equals(data));
+  });
+
+  test(
+      '[obfuscateLog] should obfuscate data when [setObfuscateLogCallback] has set a callback',
+      () async {
+    final obfuscated = data.copyWith(requestBody: 'obfuscated');
+    final completer = Completer<NetworkData>();
+    FutureOr<NetworkData> callback(NetworkData data) {
+      completer.complete(data);
+      return obfuscated;
+    }
+
+    manager.setObfuscateLogCallback(callback);
+
+    final result = await manager.obfuscateLog(data);
+
+    expect(completer.isCompleted, isTrue);
+
+    expect(await completer.future, data);
+
+    expect(result, equals(obfuscated));
+  });
+}


### PR DESCRIPTION
## Description of the change

Add network logs obfuscation support through the new `NetworkLogger.obfuscateLog` API.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: MOB-12523
## Checklists
### Development
- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
