### PR TITLE
feat: add new repro steps api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@
 
 - Add network logs obfuscation support using the new `NetworkLogger.obfuscateLog` API ([#380](https://github.com/Instabug/Instabug-Flutter/pull/380)).
 - Add network logs omission support using the new `NetworkLogger.omitLog` API ([#382](https://github.com/Instabug/Instabug-Flutter/pull/382)).
+- Add the new repro steps configuration API `Instabug.setReproStepsConfig` ([#388](https://github.com/Instabug/Instabug-Flutter/pull/388)).
 
 ### Changed
 
 - Bump Instabug iOS SDK to v11.14.0 ([#383](https://github.com/Instabug/Instabug-Flutter/pull/383)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.14.0).
+
+### Deprecated
+
+- Deprecate `Instabug.setReproStepsMode` in favor of the new `Instabug.setReproStepsConfig` ([#388](https://github.com/Instabug/Instabug-Flutter/pull/388)).
 
 ## [11.13.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.12.0...v11.13.0) (July 10, 2023)
 

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -308,7 +308,7 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
 
             if (crashMode != null) {
                 final Integer resolvedCrashMode = ArgsRegistry.reproModes.get(crashMode);
-                builder.setIssueMode(IssueType.Bug, resolvedCrashMode);
+                builder.setIssueMode(IssueType.Crash, resolvedCrashMode);
             }
 
             final ReproConfigurations config = builder.build();

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -19,7 +19,9 @@ import com.instabug.library.Feature;
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder;
+import com.instabug.library.IssueType;
 import com.instabug.library.Platform;
+import com.instabug.library.ReproConfigurations;
 import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
 import com.instabug.library.model.NetworkLog;
@@ -284,10 +286,34 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
     }
 
     @Override
+    @Deprecated()
     public void setReproStepsMode(@NonNull String mode) {
         try {
             final State resolvedMode = ArgsRegistry.reproStates.get(mode);
             Instabug.setReproStepsState(resolvedMode);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void setReproStepsConfig(@Nullable String bugMode, @Nullable String crashMode) {
+        try {
+            final ReproConfigurations.Builder builder = new ReproConfigurations.Builder();
+
+            if (bugMode != null) {
+                final Integer resolvedBugMode = ArgsRegistry.reproModes.get(bugMode);
+                builder.setIssueMode(IssueType.Bug, resolvedBugMode);
+            }
+
+            if (crashMode != null) {
+                final Integer resolvedCrashMode = ArgsRegistry.reproModes.get(crashMode);
+                builder.setIssueMode(IssueType.Bug, resolvedCrashMode);
+            }
+
+            final ReproConfigurations config = builder.build();
+
+            Instabug.setReproConfigurations(config);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/InstabugApi.java
@@ -285,6 +285,7 @@ public class InstabugApi implements InstabugPigeon.InstabugHostApi {
         // iOS Only
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     @Deprecated()
     public void setReproStepsMode(@NonNull String mode) {

--- a/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
@@ -9,6 +9,7 @@ import com.instabug.featuresrequest.ActionType;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder.Key;
 import com.instabug.library.OnSdkDismissCallback.DismissType;
+import com.instabug.library.ReproMode;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
 import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
@@ -115,6 +116,12 @@ public final class ArgsRegistry {
         put("ReproStepsMode.enabledWithNoScreenshots", State.ENABLED_WITH_NO_SCREENSHOTS);
         put("ReproStepsMode.enabled", State.ENABLED);
         put("ReproStepsMode.disabled", State.DISABLED);
+    }};
+
+    public static final ArgsMap<Integer> reproModes = new ArgsMap<Integer>() {{
+        put("ReproStepsMode.enabledWithNoScreenshots", ReproMode.EnableWithNoScreenshots);
+        put("ReproStepsMode.enabled", ReproMode.EnableWithScreenshots);
+        put("ReproStepsMode.disabled", ReproMode.Disable);
     }};
 
     public static final ArgsMap<InstabugLocale> locales = new ArgsMap<InstabugLocale>() {{

--- a/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
+++ b/android/src/main/java/com/instabug/flutter/util/ArgsRegistry.java
@@ -112,6 +112,7 @@ public final class ArgsRegistry {
         put("ExtendedBugReportMode.disabled", ExtendedBugReport.State.DISABLED);
     }};
 
+    @Deprecated()
     public static final ArgsMap<State> reproStates = new ArgsMap<State>() {{
         put("ReproStepsMode.enabledWithNoScreenshots", State.ENABLED_WITH_NO_SCREENSHOTS);
         put("ReproStepsMode.enabled", State.ENABLED);

--- a/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
+++ b/android/src/test/java/com/instabug/flutter/ArgsRegistryTest.java
@@ -10,6 +10,7 @@ import com.instabug.flutter.util.ArgsRegistry;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.InstabugCustomTextPlaceHolder.Key;
 import com.instabug.library.OnSdkDismissCallback.DismissType;
+import com.instabug.library.ReproMode;
 import com.instabug.library.extendedbugreport.ExtendedBugReport;
 import com.instabug.library.internal.module.InstabugLocale;
 import com.instabug.library.invocation.InstabugInvocationEvent;
@@ -183,6 +184,7 @@ public class ArgsRegistryTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReproStates() {
         State[] values = {
@@ -193,6 +195,19 @@ public class ArgsRegistryTest {
 
         for (State value : values) {
             assertTrue(ArgsRegistry.reproStates.containsValue(value));
+        }
+    }
+
+    @Test
+    public void testReproModes() {
+        Integer[] values = {
+                ReproMode.Disable,
+                ReproMode.EnableWithScreenshots,
+                ReproMode.EnableWithNoScreenshots,
+        };
+
+        for (Integer value : values) {
+            assertTrue(ArgsRegistry.reproModes.containsValue(value));
         }
     }
 

--- a/example/ios/InstabugTests/ArgsRegistryTests.m
+++ b/example/ios/InstabugTests/ArgsRegistryTests.m
@@ -157,7 +157,7 @@
     }
 }
 
-- (void)testReproStates {
+- (void)testReproModes {
     NSArray *values = @[
         @(IBGUserStepsModeEnable),
         @(IBGUserStepsModeDisable),
@@ -165,7 +165,7 @@
     ];
 
     for (NSNumber *value in values) {
-        XCTAssertTrue([[ArgsRegistry.reproStates allValues] containsObject:value]);
+        XCTAssertTrue([[ArgsRegistry.reproModes allValues] containsObject:value]);
     }
 }
 

--- a/example/ios/InstabugTests/InstabugApiTests.m
+++ b/example/ios/InstabugTests/InstabugApiTests.m
@@ -300,6 +300,17 @@
     OCMVerify([self.mInstabug setReproStepsMode:IBGUserStepsModeEnable]);
 }
 
+- (void)testSetReproStepsConfig {
+    NSString *bugMode = @"ReproStepsMode.enabled";
+    NSString *crashMode = @"ReproStepsMode.disabled";
+    FlutterError *error;
+
+    [self.api setReproStepsConfigBugMode:bugMode crashMode:crashMode error:&error];
+
+    OCMVerify([self.mInstabug setReproStepsFor:IBGIssueTypeBug withMode:IBGUserStepsModeEnable]);
+    OCMVerify([self.mInstabug setReproStepsFor:IBGIssueTypeCrash withMode:IBGUserStepsModeDisable]);
+}
+
 - (void)testReportScreenChange {
     NSString *screenName = @"HomeScreen";
     FlutterError *error;

--- a/ios/Classes/Modules/InstabugApi.m
+++ b/ios/Classes/Modules/InstabugApi.m
@@ -159,8 +159,20 @@ extern void InitInstabugApi(id<FlutterBinaryMessenger> messenger) {
 }
 
 - (void)setReproStepsModeMode:(NSString *)mode error:(FlutterError *_Nullable *_Nonnull)error {
-    IBGUserStepsMode resolvedMode = (ArgsRegistry.reproStates[mode]).integerValue;
+    IBGUserStepsMode resolvedMode = (ArgsRegistry.reproModes[mode]).integerValue;
     [Instabug setReproStepsMode:resolvedMode];
+}
+
+- (void)setReproStepsConfigBugMode:(nullable NSString *)bugMode crashMode:(nullable NSString *)crashMode error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error {
+    if (bugMode != nil) {
+        IBGUserStepsMode resolvedBugMode = ArgsRegistry.reproModes[bugMode].integerValue;
+        [Instabug setReproStepsFor:IBGIssueTypeBug withMode:resolvedBugMode];
+    }
+    
+    if (crashMode != nil) {
+        IBGUserStepsMode resolvedCrashMode = ArgsRegistry.reproModes[crashMode].integerValue;
+        [Instabug setReproStepsFor:IBGIssueTypeCrash withMode:resolvedCrashMode];
+    }
 }
 
 - (UIImage *)getImageForAsset:(NSString *)assetName {

--- a/ios/Classes/Util/ArgsRegistry.h
+++ b/ios/Classes/Util/ArgsRegistry.h
@@ -17,7 +17,7 @@ typedef NSDictionary<NSString *, NSNumber *> ArgsDictionary;
 + (ArgsDictionary *)dismissTypes;
 + (ArgsDictionary *)actionTypes;
 + (ArgsDictionary *)extendedBugReportStates;
-+ (ArgsDictionary *)reproStates;
++ (ArgsDictionary *)reproModes;
 + (ArgsDictionary *)locales;
 + (NSDictionary<NSString *, NSString *> *)placeholders;
 

--- a/ios/Classes/Util/ArgsRegistry.m
+++ b/ios/Classes/Util/ArgsRegistry.m
@@ -112,7 +112,7 @@
     };
 }
 
-+ (ArgsDictionary *)reproStates {
++ (ArgsDictionary *)reproModes {
     return @{
         @"ReproStepsMode.enabled" : @(IBGUserStepsModeEnable),
         @"ReproStepsMode.disabled" : @(IBGUserStepsModeDisable),

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -393,8 +393,30 @@ class Instabug {
 
   /// Sets the repro steps mode
   /// [mode] repro steps mode
+  @Deprecated('Use [setReproStepsConfig] instead.')
   static Future<void> setReproStepsMode(ReproStepsMode reproStepsMode) async {
     return _host.setReproStepsMode(reproStepsMode.toString());
+  }
+
+  /// Sets the repro steps mode for bugs and crashes.
+  /// [bug] repro steps mode for bug reports.
+  /// [crash] repro steps mode for crash reports.
+  /// [all] repro steps mode for both bug and crash reports, when present it
+  /// overrides [bug] and [crash].
+  static Future<void> setReproStepsConfig({
+    ReproStepsMode? bug,
+    ReproStepsMode? crash,
+    ReproStepsMode? all,
+  }) async {
+    if (all != null) {
+      bug = all;
+      crash = all;
+    }
+
+    return _host.setReproStepsConfig(
+      bug.toString(),
+      crash.toString(),
+    );
   }
 
   /// Sets a custom branding image logo with [light] and [dark] images for different color modes.

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -417,14 +417,25 @@ class Instabug {
     ReproStepsMode? crash,
     ReproStepsMode? all,
   }) async {
+    var bugMode = bug;
+    var crashMode = crash;
+
     if (all != null) {
-      bug = all;
-      crash = all;
+      bugMode = all;
+      crashMode = all;
+    }
+
+    // There's an issue with crashes repro steps with screenshots in the iOS SDK
+    // at the moment, so we'll map enabled with screenshots to enabled with no
+    // screenshots to avoid storing the images on disk if it's not needed until
+    // this issue is fixed in a future version.
+    if (IBGBuildInfo.I.isIOS && crashMode == ReproStepsMode.enabled) {
+      crashMode = ReproStepsMode.enabledWithNoScreenshots;
     }
 
     return _host.setReproStepsConfig(
-      bug.toString(),
-      crash.toString(),
+      bugMode.toString(),
+      crashMode.toString(),
     );
   }
 

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -399,10 +399,19 @@ class Instabug {
   }
 
   /// Sets the repro steps mode for bugs and crashes.
+  ///
   /// [bug] repro steps mode for bug reports.
   /// [crash] repro steps mode for crash reports.
   /// [all] repro steps mode for both bug and crash reports, when present it
   /// overrides [bug] and [crash].
+  ///
+  /// Example:
+  /// ```dart
+  /// Instabug.setReproStepsConfig(
+  ///  bug: ReproStepsMode.enabledWithNoScreenshots,
+  ///  crash: ReproStepsMode.enabled,
+  ///  );
+  ///  ```
   static Future<void> setReproStepsConfig({
     ReproStepsMode? bug,
     ReproStepsMode? crash,

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -408,9 +408,9 @@ class Instabug {
   /// Example:
   /// ```dart
   /// Instabug.setReproStepsConfig(
-  ///  bug: ReproStepsMode.enabledWithNoScreenshots,
-  ///  crash: ReproStepsMode.enabled,
-  ///  );
+  ///   bug: ReproStepsMode.enabled,
+  ///   crash: ReproStepsMode.disabled,
+  /// );
   ///  ```
   static Future<void> setReproStepsConfig({
     ReproStepsMode? bug,

--- a/pigeons/instabug.api.dart
+++ b/pigeons/instabug.api.dart
@@ -42,7 +42,9 @@ abstract class InstabugHostApi {
   void setDebugEnabled(bool enabled);
   void setSdkDebugLogsLevel(String level);
 
+  @Deprecated('Use [setReproStepsConfig] instead')
   void setReproStepsMode(String mode);
+  void setReproStepsConfig(String? bugMode, String? crashMode);
   void reportScreenChange(String screenName);
 
   void setCustomBrandingImage(String light, String dark);

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -312,6 +312,8 @@ void main() {
     const bug = ReproStepsMode.enabled;
     const crash = ReproStepsMode.enabledWithNoScreenshots;
 
+    when(mBuildInfo.isIOS).thenReturn(false);
+
     await Instabug.setReproStepsConfig(
       bug: bug,
       crash: crash,

--- a/test/instabug_test.dart
+++ b/test/instabug_test.dart
@@ -300,10 +300,37 @@ void main() {
   test('[setReproStepsMode] should call host method', () async {
     const mode = ReproStepsMode.enabled;
 
+    // ignore: deprecated_member_use_from_same_package
     await Instabug.setReproStepsMode(mode);
 
     verify(
       mHost.setReproStepsMode(mode.toString()),
+    ).called(1);
+  });
+
+  test('[setReproStepsConfig] should call host method', () async {
+    const bug = ReproStepsMode.enabled;
+    const crash = ReproStepsMode.enabledWithNoScreenshots;
+
+    await Instabug.setReproStepsConfig(
+      bug: bug,
+      crash: crash,
+    );
+
+    verify(
+      mHost.setReproStepsConfig(bug.toString(), crash.toString()),
+    ).called(1);
+  });
+
+  test(
+      '[setReproStepsConfig] should use [all] for [bug] and [crash] if present',
+      () async {
+    const all = ReproStepsMode.enabled;
+
+    await Instabug.setReproStepsConfig(all: all);
+
+    verify(
+      mHost.setReproStepsConfig(all.toString(), all.toString()),
     ).called(1);
   });
 


### PR DESCRIPTION
## Description of the change

Add support for the new `Instabug.setReproStepsConfig` API and deprecate the old `Instabug.setReproStepsMode`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13005

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
