### PR TITLE
chore: use `dart run` instead of `flutter pub run`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - checkout
       - run: flutter pub get
       - run: sh ./scripts/pigeon.sh
-      - run: flutter pub run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter test --coverage
       - run:
           working_directory: coverage
@@ -194,7 +194,7 @@ jobs:
       - checkout
       - run: flutter pub get
       - run: sh ./scripts/pigeon.sh
-      - run: flutter pub run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs
       - run:
           name: Perform Static Analysis
           command: flutter analyze
@@ -206,10 +206,10 @@ jobs:
       - checkout
       - run: flutter pub get
       - run: sh ./scripts/pigeon.sh
-      - run: flutter pub run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs
       - run:
           name: Check Package Score
-          command: flutter pub run pana --no-warning --exit-code-threshold 0
+          command: dart run pana --no-warning --exit-code-threshold 0
       - run: flutter pub publish --dry-run
 
   release:

--- a/scripts/pigeon.sh
+++ b/scripts/pigeon.sh
@@ -14,7 +14,7 @@ generate_pigeon() {
   name_snake=$(basename $name_file .api.dart)
   name_pascal=$(echo "$name_snake" | perl -pe 's/(^|_)./uc($&)/ge;s/_//g')
 
-  flutter pub run pigeon \
+  dart run pigeon \
       --input "pigeons/$name_snake.api.dart" \
       --dart_out "$DIR_DART/$name_snake.api.g.dart" \
       --objc_header_out "$DIR_IOS/${name_pascal}Pigeon.h" \


### PR DESCRIPTION
## Description of the change

`flutter pub run` has been deprecated in favor of `dart run` for some time now, we are migrating to `dart run` instead.

Whenever you use `flutter pub run` you’d get this log if you’re on a newer version of Flutter and Dart.

> Deprecated. Use `dart run` instead.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13178

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
