### PR TITLE
fix(ios): enable screenshots for crashes & sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Bump Instabug iOS SDK to v12.2.0 ([#406](https://github.com/Instabug/Instabug-Flutter/pull/406)). [See release notes](https://github.com/instabug/instabug-ios/releases/tag/12.2.0).
 - Bump Instabug Android SDK to v12.2.0 ([#405](https://github.com/Instabug/Instabug-Flutter/pull/405)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.2.0).
 
+### Fixed
+
+- Re-enable screenshot capturing for Crash Reporting and Session Replay by removing redundant mapping ([#407](https://github.com/Instabug/Instabug-Flutter/pull/407)). 
+
 ## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.1.0...v11.14.0)
 
 ### Added

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -383,14 +383,6 @@ class Instabug {
       sessionReplayMode = all;
     }
 
-    // There's an issue with crashes repro steps with screenshots in the iOS SDK
-    // at the moment, so we'll map enabled with screenshots to enabled with no
-    // screenshots to avoid storing the images on disk if it's not needed until
-    // this issue is fixed in a future version.
-    if (IBGBuildInfo.I.isIOS && crashMode == ReproStepsMode.enabled) {
-      crashMode = ReproStepsMode.enabledWithNoScreenshots;
-    }
-
     return _host.setReproStepsConfig(
       bugMode.toString(),
       crashMode.toString(),


### PR DESCRIPTION
## Description of the change
Remove unnecessary mapping that mapped ReproStepsMode.enabled to ReproStepsMode.enabledWithNoScreenshots for iOS platform. This workaround was added due to an [issue](https://instabug.atlassian.net/browse/IBGCRASH-19924) with crashes repro steps with screenshots in the iOS SDK, and now it's no longer needed as the issue has been resolved. This re-enabled it for Crash Reporting and Session Replay.
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: [IBGCRASH-20557](https://instabug.atlassian.net/browse/IBGCRASH-20557)
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 


[IBGCRASH-20557]: https://instabug.atlassian.net/browse/IBGCRASH-20557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ