### PR TITLE
chore: add separators between version sections changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Bump Instabug iOS SDK to v12.2.0 ([#406](https://github.com/Instabug/Instabug-Flutter/pull/406)). [See release notes](https://github.com/instabug/instabug-ios/releases/tag/12.2.0).
 - Bump Instabug Android SDK to v12.2.0 ([#405](https://github.com/Instabug/Instabug-Flutter/pull/405)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.2.0).
 
-## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.1.0...v11.14.0)
+## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.14.0...v12.1.0) (September, 28, 2023)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/12.1.0...dev)
+
+### Changed
+
+- Bump Instabug Android SDK to v12.2.0 ([#405](https://github.com/Instabug/Instabug-Flutter/pull/405)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.2.0).
+
 ## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.1.0...v11.14.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Bump Instabug iOS SDK to v12.2.0 ([#406](https://github.com/Instabug/Instabug-Flutter/pull/406)). [See release notes](https://github.com/instabug/instabug-ios/releases/tag/12.2.0).
 - Bump Instabug Android SDK to v12.2.0 ([#405](https://github.com/Instabug/Instabug-Flutter/pull/405)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.2.0).
 
+---
+
 ## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.14.0...v12.1.0) (September, 28, 2023)
 
 ### Added
@@ -18,6 +20,8 @@
 - **BREAKING** Remove deprecated APIs ([#385](https://github.com/Instabug/Instabug-Flutter/pull/385)). See migration guide for more details.
 - Bump Instabug iOS SDK to v12.1.0 ([#396](https://github.com/Instabug/Instabug-Flutter/pull/396)). See release notes for [v12.0.0](https://github.com/instabug/instabug-ios/releases/tag/12.0.0) and [v12.1.0](https://github.com/instabug/instabug-ios/releases/tag/12.1.0).
 - Bump Instabug Android SDK to v12.1.0 ([#397](https://github.com/Instabug/Instabug-Flutter/pull/397)). See release notes for [v12.0.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.0.0), [v12.0.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.0.1) and [v12.1.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.1.0).
+
+---
 
 ## [11.14.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.13.0...v11.14.0) (September 13, 2023)
 
@@ -35,6 +39,8 @@
 ### Deprecated
 
 - Deprecate `Instabug.setReproStepsMode` in favor of the new `Instabug.setReproStepsConfig` ([#388](https://github.com/Instabug/Instabug-Flutter/pull/388)).
+
+---
 
 ## [11.13.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.12.0...v11.13.0) (July 10, 2023)
 
@@ -62,6 +68,8 @@
   - `Surveys.setOnShowCallback`
   - `Surveys.setOnDismissCallback`
 
+---
+
 ## [11.12.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.10.1...v11.12.0) (May 30, 2023)
 
 ### Changed
@@ -69,11 +77,15 @@
 - Bump Instabug Android SDK to v11.12.0 ([#366](https://github.com/Instabug/Instabug-Flutter/pull/366)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.12.0).
 - Bump Instabug iOS SDK to v11.12.0 ([#365](https://github.com/Instabug/Instabug-Flutter/pull/365)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.12.0).
 
+---
+
 ## [11.10.1](https://github.com/Instabug/Instabug-Flutter/compare/v11.10.0...v11.10.1) (April 17, 2023)
 
 ### Changed
 
 - Bump Instabug iOS SDK to v11.10.1 ([#358](https://github.com/Instabug/Instabug-Flutter/pull/358)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.1).
+
+---
 
 ## [11.10.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.9.0...v11.10.0) (April 12, 2023)
 
@@ -81,6 +93,8 @@
 
 - Bump Instabug Android SDK to v11.11.0 ([#352](https://github.com/Instabug/Instabug-Flutter/pull/352)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.11.0).
 - Bump Instabug iOS SDK to v11.10.0 ([#353](https://github.com/Instabug/Instabug-Flutter/pull/353)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.0).
+
+---
 
 ## 11.9.0 (2023-02-21)
 
@@ -103,6 +117,8 @@
 - Fixes license warning on iOS.
 - Exports Instabug Android SDK using `api` instead of `implementation`.
 
+---
+
 ## 11.6.0 (2022-12-29)
 
 - Bumps Instabug Android SDK to v11.7.0
@@ -111,6 +127,8 @@
 - Fixes APM network logging on Android
 - Fixes a NullPointerException when overriding a string key that doesn't exist on Android
 - Removes redundant native logs
+
+---
 
 ## 11.5.0 (2022-11-24)
 
@@ -132,6 +150,8 @@
   3. Surveys.hasRespondedToSurvey
   4. Surveys.getAvailableSurveys
 
+---
+
 ## 11.3.0 (2022-09-30)
 
 - Bumps Instabug Android SDK to v11.5.1
@@ -141,6 +161,8 @@
 - Adds missing mapping for portuguesePortugal locale on iOS
 - Fixes an issue with some string keys not working on Android
 
+---
+
 ## 11.2.0 (2022-09-08)
 
 - Bumps Instabug Android SDK to v11.4.1
@@ -148,6 +170,8 @@
 - Fixes an issue with BugReporting.setInvocationEvents on iOS that always sets the event to none
 - Fixes an issue with network logging on iOS which caused the initial network requests logs to be skipped
 - Renames Android package from com.instabug.instabugFlutter to com.instabug.flutter
+
+---
 
 ## v11.0.0 (2022-07-20)
 
@@ -162,6 +186,8 @@
 - Removes the deprecated APIs. Check the migration guide referenced in our docs
 - Fixes an issue with Android screenshots being black on release mode on SDK v10.13.0
 
+---
+
 ## v10.13.0 (2022-03-31)
 
 - Adds support for uploading debug symbols on Android to be used for crash deobfuscation
@@ -169,11 +195,15 @@
 - Bumps Instabug native SDKs to v10.13
 - Fixes iOS platform calls not completing with `void` return type
 
+---
+
 ## v10.11.0 (2022-01-04)
 
 - Adds support for APM.endAppLaunch API
 - Bumps Instabug native SDKs to v10.11
 - Fixes an issue with APM logged requests payload size
+
+---
 
 ## v10.9.1 (2021-10-13)
 
@@ -181,22 +211,32 @@
 - Bumps Instabug iOS SDK to v10.9.3
 - Fixes an issue with network requests not getting logged on iOS
 
+---
+
 ## v10.9.0 (2021-09-28)
 
 - Migrates to Flutter Android embedding v2
 - Bumps Instabug native SDKs to v10.9
 
+---
+
 ## v10.8.0 (2021-09-13)
 
 - Introduces Instabug's new App Performance Monitoring (APM)
+
+---
 
 ## v10.0.1 (2021-08-25)
 
 - Fixes an issue with http client logger.
 
+---
+
 ## v10.0.0 (2021-08-04)
 
 - Bumps Instabug native SDKs to v10.8
+
+---
 
 ## v9.2.0 (2021-08-02)
 
@@ -204,20 +244,28 @@
 - Fixes a crash when Instabug.start API is called on Android without Platform check.
 - Changes all `void ... async` methods to `Future<void> ... async` so that callers can use `await`.
 
+---
+
 ## v9.2.0-nullsafety.0 (2021-07-14)
 
 - Adds null safety support.
 - Fixes a crash when Instabug.start API is called on Android without Platform check.
 - Changes all `void ... async` methods to `Future<void> ... async` so that callers can use `await`.
 
+---
+
 ## v9.1.9 (2021-05-11)
 
 - Adds support for overriding the replies notification string values through `repliesNotificationTeamName`, `repliesNotificationReplyButton`, `repliesNotificationDismissButton`
 - Removes the use of `android:requestLegacyExternalStorage` attribute on Android
 
+---
+
 ## v9.1.8 (2021-02-17)
 
 - Fixes an issue with iOS invocation events causing the welcome message not to show.
+
+---
 
 ## v9.1.7 (2020-10-01)
 
@@ -226,52 +274,76 @@
 - Bumps Instabug iOS SDK to v9.1.7
 - Bumps Instabug Android SDK to v9.1.8
 
+---
+
 ## v9.1.6 (2020-07-13)
 
 - Added CrashReporting
 - Added setShakingThresholdForiPhone, setShakingThresholdForiPad and setShakingThresholdForAndroid APIs
 - Added Proguard rules to protect Flutter bridge class and method names from getting obfuscated when the minifyEnabled flag is set to true.
 
+---
+
 ## v9.1.0 (2020-03-19)
 
 - Bump Native SDKs to v9.1
+
+---
 
 ## v9.0.6 (2020-01-29)
 
 - Bump iOS Native SDK to v9.0.6
 
+---
+
 ## v9.0.5 (2020-01-27)
 
 - Bump Native SDKs to v9.0.5
+
+---
 
 ## Version 9.0.1 (2019-12-12)
 
 - Added enum `CustomTextPlaceHolderKey.reportQuestion` which maps to `InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION` on Android and `kIBGAskAQuestionStringName` on iOS
 
+---
+
 ## Version 9.0.0 (2019-12-09)
 
 - Updated native SDKs to v9.0
+
+---
 
 ## Version 8.7.0 (2019-11-11)
 
 - Updates native SDK dependencies to 8.7
 
+---
+
 ## Version 8.6.4 (2019-09-16)
 
 - Updates native SDK dependencies to 8.6.3
 
+---
+
 ## Version 8.6.3 (2019-09-05)
 
 - Updates native SDK dependencies to 8.6.2
+
+---
 
 ## Version 8.6.1 (2019-08-26)
 
 - Bumps version to 8.6 to be in sync with other platforms.
 - Updates native SDK dependencies to 8.6.1.
 
+---
+
 ## Version 1.0.0 (2019-07-29)
 
 **⚠️ Package on pub has been renamed to `instabug_flutter` the old package `instabug` is deprecated**
+
+---
 
 ## Version 1.0.0-beta.5 (2019-07-22)
 
@@ -279,15 +351,21 @@
 - Fixes a linker issue on iOS when using Swift and CocoaPods.
 - Bumps native iOS and Android dependencies to version 8.5.
 
+---
+
 ## Version 1.0.0-beta.4 (2019-06-25)
 
 - Fixes crash on Android on launching the sample app.
+
+---
 
 ## Version 1.0.0-beta.3 (2019-05-28)
 
 - Fixes `Locale` enum name collision with `dart.ui` library. Use `IBGLocale` instead.
 
 - Updates Native SDK's to version 8.4
+
+---
 
 ## Version 1.0.0-beta.2 (2019-05-22)
 
@@ -296,12 +374,16 @@
 - Bump native SDK's to version 8.3
 - Fixes issue of manually invoking BugReporting
 
+---
+
 ## Version 1.0.0-beta.1 (2019-04-16)
 
 - Adds New Sample App
 - Adds Replies Api mappings
 - Adds Chats Api mappings
 - Adds FeatureRequests Api mappings.
+
+---
 
 ## Version 0.0.4 (2019-04-14)
 
@@ -329,13 +411,19 @@
 - Adds setPrimaryColor API mapping.
 - Adds setSessionProfilerEnabled API mapping.
 
+---
+
 ## Version 0.0.3 (2019-03-21)
 
 - Divides the library into separate modules: (`Instabug`, `BugReporting`, `InstabugLog`).
 
+---
+
 ## Version 0.0.2 (2019-03-20)
 
 - Adds more API mappings.
+
+---
 
 ## Version 0.0.1 (2019-03-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump Instabug iOS SDK to v12.2.0 ([#406](https://github.com/Instabug/Instabug-Flutter/pull/406)). [See release notes](https://github.com/instabug/instabug-ios/releases/tag/12.2.0).
 - Bump Instabug Android SDK to v12.2.0 ([#405](https://github.com/Instabug/Instabug-Flutter/pull/405)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.2.0).
 
 ## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.1.0...v11.14.0)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'com.instabug.library:instabug:12.1.0'
+    api 'com.instabug.library:instabug:12.2.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (12.1.0)
+  - Instabug (12.2.0)
   - instabug_flutter (12.1.0):
     - Flutter
-    - Instabug (= 12.1.0)
+    - Instabug (= 12.2.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Instabug: 3ce9b076023458324e8c5f2452a32bc0609f676d
-  instabug_flutter: 762426d07dd8614130ad19a30e00062213e048ea
+  Instabug: 3eb90033224ef6b072ab9b2e739f62fe88a7edaa
+  instabug_flutter: 86e2b415bf1156887ecc9fcb9824a1bc5d99376b
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 637e800c0a0982493b68adb612d2dd60c15c8e5c
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '12.1.0'
+  s.dependency 'Instabug', '12.2.0'
 end
 


### PR DESCRIPTION
## Description of the change
- Add horizontal separators between versions
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
- [\[MOB-13259\] \[CP\] \[FLT\] Add horizontal separators between version release sections in `CHANGELOG.md` - JIRA](https://instabug.atlassian.net/browse/MOB-13259)
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
