### PR TITLE
ci: add `dart pub get` for release (#415)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,10 @@ jobs:
           flutter_version: 3.3.6
           app-dir: project
       - run:
+          name: Install pub packages
+          working_directory: ~/project
+          command: dart pub get
+      - run:
           name: Generate Pigeons
           working_directory: project
           command: sh ./scripts/pigeon.sh


### PR DESCRIPTION


## Description of the change
- fix ci failure due to pubs not being downloaded; utilize `dart pub get` in release pipeline
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: [\[MOB-13261\] Fix failing CI for pigeon generation](https://instabug.atlassian.net/browse/MOB-13261)
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
