### PR TITLE
chore(ios): bump sdk to v12.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v12.2.0...dev)
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v12.2.0...dev)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v12.2.0...dev)
+
+### Changed
+
+- Bump Instabug iOS SDK to v12.4.0 ([#419](https://github.com/Instabug/Instabug-Flutter/pull/419)). See release notes for [v12.3.0](https://github.com/instabug/instabug-ios/releases/tag/12.3.0) and [v12.4.0](https://github.com/instabug/instabug-ios/releases/tag/12.4.0).
+
 ## [12.2.0](https://github.com/Instabug/Instabug-Flutter/compare/12.1.0...12.2.0) (Tuesday, 14, 2023)
 
 ### Changed

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (12.2.0)
+  - Instabug (12.4.0)
   - instabug_flutter (12.2.0):
     - Flutter
-    - Instabug (= 12.2.0)
+    - Instabug (= 12.4.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Instabug: 3eb90033224ef6b072ab9b2e739f62fe88a7edaa
-  instabug_flutter: d80eb57067a9103e83888d3959de6eae26dfaa5a
+  Instabug: 83bde9d7d4b582ea8f14935f79f1ce39af55e149
+  instabug_flutter: 155ef8b51321fb7d5aa1f6400a5c829042ba998a
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 637e800c0a0982493b68adb612d2dd60c15c8e5c

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '12.2.0'
+  s.dependency 'Instabug', '12.4.0'
 end
 


### PR DESCRIPTION
## Description of the change
Bump iOS SDK to `v12.4.0`
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: MOB-13353
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
