### PR TITLE
chore(android): bump android sdk to v12.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Bump Instabug iOS SDK to v12.4.0 ([#419](https://github.com/Instabug/Instabug-Flutter/pull/419)). See release notes for [v12.3.0](https://github.com/instabug/instabug-ios/releases/tag/12.3.0) and [v12.4.0](https://github.com/instabug/instabug-ios/releases/tag/12.4.0).
+- Bump Instabug Android SDK to v12.4.1 ([#420](https://github.com/Instabug/Instabug-Flutter/pull/420)). See release notes for [v12.3.0](https://github.com/Instabug/android/releases/tag/v12.3.0), [v12.3.1](https://github.com/Instabug/android/releases/tag/v12.3.1), [v12.4.0](https://github.com/Instabug/android/releases/tag/v12.4.0) and [v12.4.1](https://github.com/Instabug/android/releases/tag/v12.4.1).
 
 ## [12.2.0](https://github.com/Instabug/Instabug-Flutter/compare/12.1.0...12.2.0) (Tuesday, 14, 2023)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'com.instabug.library:instabug:12.2.0'
+    api 'com.instabug.library:instabug:12.4.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"


### PR DESCRIPTION
## Description of the change
Bump Android SDK to `v12.4.1`
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: MOB-13352
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
