### PR TITLE
chore(android): bump sdk to v12.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v12.4.0...dev)
+
+### Changed
+
+- Bump Instabug Android SDK to v12.5.0 ([#424](https://github.com/Instabug/Instabug-Flutter/pull/424)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.5.0).
+
 ## [12.4.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.2.0...12.4.0) (December 13, 2023)
 
 ### Changed
@@ -16,7 +22,7 @@
 
 ### Fixed
 
-- Re-enable screenshot capturing for Crash Reporting and Session Replay by removing redundant mapping ([#407](https://github.com/Instabug/Instabug-Flutter/pull/407)). 
+- Re-enable screenshot capturing for Crash Reporting and Session Replay by removing redundant mapping ([#407](https://github.com/Instabug/Instabug-Flutter/pull/407)).
 
 ## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.14.0...v12.1.0) (September 28, 2023)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'com.instabug.library:instabug:12.4.1'
+    api 'com.instabug.library:instabug:12.5.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"


### PR DESCRIPTION
## Description of the change

Bump Instabug Android SDK to v12.5.0

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13518

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
