### PR TITLE
chore(ios): bump sdk to v12.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump Instabug iOS SDK to v12.5.0 ([#425](https://github.com/Instabug/Instabug-Flutter/pull/425)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/12.5.0).
 - Bump Instabug Android SDK to v12.5.1 ([#426](https://github.com/Instabug/Instabug-Flutter/pull/426)). See release notes for [v12.5.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.5.0) and [12.5.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.5.1).
 
 ## [12.4.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.2.0...12.4.0) (December 13, 2023)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (12.4.0)
+  - Instabug (12.5.0)
   - instabug_flutter (12.4.0):
     - Flutter
-    - Instabug (= 12.4.0)
+    - Instabug (= 12.5.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Instabug: 83bde9d7d4b582ea8f14935f79f1ce39af55e149
-  instabug_flutter: 909ae8f00821f97e91dd3792c3cdc45965025df5
+  Instabug: 7c7421ae87838010b47a60d9b56378be2482ab64
+  instabug_flutter: b476a6fc0bb2cfb9cf89edae17ad67270be75af5
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 637e800c0a0982493b68adb612d2dd60c15c8e5c

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '12.4.0'
+  s.dependency 'Instabug', '12.5.0'
 end
 


### PR DESCRIPTION
## Description of the change

Bump Instabug iOS SDK to v12.5.0

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: MOB-13519
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
