### PR TITLE
fix: android `showSurvey` ANR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v12.5.0...dev)
+
+### Fixed
+
+- Fix an Android issue with `showSurvey` causing ANR when invoked from the main thread. The fix ensures its execution on the background thread by default. ([#454]()).
+
 ## [12.5.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.4.0...v12.5.0) (January 08 , 2024)
 
 ### Changed

--- a/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/SurveysApi.java
@@ -1,21 +1,29 @@
 package com.instabug.flutter.modules;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.instabug.flutter.generated.SurveysPigeon;
+import com.instabug.flutter.util.Reflection;
 import com.instabug.flutter.util.ThreadManager;
 import com.instabug.library.Feature;
+import com.instabug.library.Platform;
 import com.instabug.survey.Survey;
 import com.instabug.survey.Surveys;
 import com.instabug.survey.callbacks.OnDismissCallback;
 import com.instabug.survey.callbacks.OnShowCallback;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 public class SurveysApi implements SurveysPigeon.SurveysHostApi {
+
+    private final String TAG = InstabugApi.class.getName();
     private final SurveysPigeon.SurveysFlutterApi flutterApi;
 
     public static void init(BinaryMessenger messenger) {
@@ -42,9 +50,28 @@ public class SurveysApi implements SurveysPigeon.SurveysHostApi {
         Surveys.showSurveyIfAvailable();
     }
 
+    /**
+     * Displays a survey using reflection, eliminating the need to call it on a background thread.
+     * This variant does not return a boolean indicating the existence of the survey.
+     * Invoked through reflection.
+     */
+    @VisibleForTesting
+    public void showSurveyCP(@NonNull String surveyToken) {
+        try {
+            Method method = Reflection.getMethod(Class.forName("com.instabug.survey.Surveys"), "showSurveyCP", String.class);
+            if (method != null) {
+                method.invoke(null, surveyToken);
+            } else {
+                Log.e(TAG, "showSurveyCP was not found by reflection");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     @Override
     public void showSurvey(@NonNull String surveyToken) {
-        Surveys.showSurvey(surveyToken);
+        showSurveyCP(surveyToken);
     }
 
     @Override

--- a/android/src/test/java/com/instabug/flutter/SurveysApiTest.java
+++ b/android/src/test/java/com/instabug/flutter/SurveysApiTest.java
@@ -1,18 +1,22 @@
 package com.instabug.flutter;
 
+import static com.instabug.flutter.util.GlobalMocks.reflected;
 import static com.instabug.flutter.util.MockResult.makeResult;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import com.instabug.flutter.generated.SurveysPigeon;
 import com.instabug.flutter.modules.SurveysApi;
 import com.instabug.flutter.util.GlobalMocks;
+import com.instabug.flutter.util.MockReflected;
 import com.instabug.library.Feature;
+import com.instabug.library.Platform;
 import com.instabug.survey.Survey;
 import com.instabug.survey.Surveys;
 import com.instabug.survey.callbacks.OnDismissCallback;
@@ -83,12 +87,22 @@ public class SurveysApiTest {
     }
 
     @Test
+    public void testShowSurveyCp() {
+        String token = "survey-token";
+
+        api.showSurveyCP(token);
+
+        reflected.verify(() -> MockReflected.showSurveyCP(token));
+    }
+
+    @Test
     public void testShowSurvey() {
         String token = "survey-token";
 
         api.showSurvey(token);
 
-        mSurveys.verify(() -> Surveys.showSurvey(token));
+        reflected.verify(() -> MockReflected.showSurveyCP(token));
+        mSurveys.verify(() -> Surveys.showSurvey(token), never());
     }
 
     @Test

--- a/android/src/test/java/com/instabug/flutter/util/GlobalMocks.java
+++ b/android/src/test/java/com/instabug/flutter/util/GlobalMocks.java
@@ -77,6 +77,12 @@ public class GlobalMocks {
 
         uri = mockStatic(Uri.class);
         uri.when(() -> Uri.fromFile(any())).thenReturn(mock(Uri.class));
+
+        Method mShowSurveyCP = MockReflected.class.getDeclaredMethod("showSurveyCP", String.class);
+        mShowSurveyCP.setAccessible(true);
+        reflection
+                .when(() -> Reflection.getMethod(Class.forName("com.instabug.survey.Surveys"), "showSurveyCP", String.class))
+                .thenReturn(mShowSurveyCP);
     }
 
     public static void close() {

--- a/android/src/test/java/com/instabug/flutter/util/MockReflected.java
+++ b/android/src/test/java/com/instabug/flutter/util/MockReflected.java
@@ -36,4 +36,9 @@ public class MockReflected {
      * CrashReporting.reportException
      */
     public static void crashReportException(JSONObject exception, boolean isHandled) {}
+
+    /**
+     * Surveys.showSurveyCP
+     */
+    public static void showSurveyCP(String surveyToken) {}
 }


### PR DESCRIPTION
## Description of the change
Modify the `Surveys.showSurvey` to call the newly added private Android SDK API `SurveysshowSurveyCP`. This ensures that the showSurvey is called on the background thread by default eliminating any ANRs from occurring.
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira IDs:
- INSD-10685
- MOB-13622
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
