### PR TITLE
ci: migrate macos machines to m1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
   setup_flutter:
     steps:
       - flutter/install_sdk_and_pub:
-          flutter_version: 3.10.5
+          version: 3.10.5
       - run:
           name: Generate Pigeons
           command: sh ./scripts/pigeon.sh
@@ -248,7 +248,7 @@ jobs:
       - checkout:
           path: ~/project
       - flutter/install_sdk_and_pub:
-          flutter_version: 3.3.6
+          version: 3.3.6
           app-dir: project
       - run:
           name: Install pub packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.0
-  flutter: circleci/flutter@1.0
+  flutter: circleci/flutter@2.0.2
   node: circleci/node@5.1.0
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ jobs:
   test_ios:
     macos:
       xcode: 13.4.1
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - setup_ios
@@ -188,7 +189,7 @@ jobs:
   e2e_ios_captain:
     macos:
       xcode: 13.4.1
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - setup_captain:
@@ -241,6 +242,7 @@ jobs:
   release:
     macos:
       xcode: 13.4.1
+    resource_class: macos.m1.medium.gen1
     working_directory: "~"
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ commands:
           command: sh ./scripts/pigeon.sh
   setup_ios:
     steps:
+      # Flutter doesn't support Apple Silicon yet, so we need to install Rosetta use Flutter on M1 machines.
+      - run:
+          name: Install Rosetta
+          command: softwareupdate --install-rosetta --agree-to-license
       - setup_flutter
       - run:
           name: Install CocoaPods


### PR DESCRIPTION
## Description of the change

Migrate CircleCI macOS machines to M1 medium.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13335

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
