### PR TITLE
chore(ios): bump sdk to v12.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support user identification using ID ([#435](https://github.com/Instabug/Instabug-Flutter/pull/435)).
 
+### Changed
+
+- Bump Instabug Android SDK to v12.7.1 ([#439](https://github.com/Instabug/Instabug-Flutter/pull/439)). See release notes for [v12.7.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.7.1).
+
 ## [12.5.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.4.0...v12.5.0) (January 08 , 2024)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Bump Instabug iOS SDK to v12.7.0 ([#440](https://github.com/Instabug/Instabug-Flutter/pull/440)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/12.7.0).
 - Bump Instabug Android SDK to v12.7.1 ([#439](https://github.com/Instabug/Instabug-Flutter/pull/439)). See release notes for [v12.7.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.7.1).
 
 ## [12.5.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.4.0...v12.5.0) (January 08 , 2024)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'com.instabug.library:instabug:12.5.1'
+    api 'com.instabug.library:instabug:12.7.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (12.5.0)
+  - Instabug (12.7.0)
   - instabug_flutter (12.5.0):
     - Flutter
-    - Instabug (= 12.5.0)
+    - Instabug (= 12.7.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Instabug: 7c7421ae87838010b47a60d9b56378be2482ab64
-  instabug_flutter: 6616282da25073d743a4bb549a7b36ac60304fff
+  Instabug: 59f0b0bc2c062b5cdbbf417cca365480a1fe55d8
+  instabug_flutter: 63041d3a18b8ab1fc74784158a5f290d0d21da37
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 637e800c0a0982493b68adb612d2dd60c15c8e5c

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '12.5.0'
+  s.dependency 'Instabug', '12.7.0'
 end
 


### PR DESCRIPTION
## Description of the change

Bump Instabug iOS SDK to `v12.7.0`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13985

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
