### PR TITLE
ci: fix release job by installing rosetta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,10 @@ jobs:
     steps:
       - checkout:
           path: ~/project
+      # Flutter doesn't support Apple Silicon yet, so we need to install Rosetta use Flutter on M1 machines.
+      - run:
+          name: Install Rosetta
+          command: softwareupdate --install-rosetta --agree-to-license
       - flutter/install_sdk_and_pub:
           version: 3.3.6
           app-dir: project


### PR DESCRIPTION
## Description of the change

The `release` CI job fails to run after the M1 upgrade because Flutter isn’t compatible with Apple Silicon and we need to install Rosetta 2 to get it to work.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13988

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
