### PR TITLE
ci: upgrade android orb, node orbe android image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
-          additional-avd-args: -d "pixel_4"
+#          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
@@ -168,7 +168,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
-          additional-avd-args: -d "pixel_4"
+#          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,8 +145,12 @@ jobs:
     steps:
       - checkout
       - setup_flutter
+      - android/create-avd:
+            avd-name: testavd
+            install: true
+            system-image: system-images;android-29;default;x86
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-29;default;x86
+          system-image: testavd
           # additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
@@ -293,9 +297,9 @@ workflows:
           name: test_flutter-2.10.5
           version: 2.10.5
       - test_android
-      - e2e_android_captain
-      - test_ios
-      - e2e_ios_captain
+      # - e2e_android_captain
+      # - test_ios
+      # - e2e_ios_captain
       - format_flutter
       - lint_flutter:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - checkout
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86
+          system-image: system-images;android-33;google_apis;x86_64
           # additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
@@ -166,7 +166,7 @@ jobs:
           platform: android
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86
+          system-image: system-images;android-33;google_apis;x86_64
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   android: circleci/android@2.5.0
   flutter: circleci/flutter@2.0.2
   node: circleci/node@5.2.0
+  advanced-checkout: vsco/advanced-checkout@1.1.0
 
 commands:
   setup_flutter:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,8 +182,8 @@ jobs:
           working_directory:  ~/project/example/ios
           command: |
             xcodebuild -allowProvisioningUpdates \
-                -workspace InstabugExample.xcworkspace \
-                -scheme InstabugExample \
+                -workspace Runner.xcworkspace \
+                -scheme Runner \
                 -resultBundlePath coverage/result.xcresult \
                 -sdk iphonesimulator \
                 -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max,OS=15.5' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - checkout
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86_64
+          system-image: system-images;android-33;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
@@ -166,7 +166,7 @@ jobs:
           platform: android
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86_64
+          system-image: system-images;android-33;google_apis;x86
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - advanced-checkout/shallow-checkout
       - setup_flutter
       - android/run-tests:
-          working-directory: ~/project/examples/android
+          working-directory: example/android
           test-command: ./gradlew test
 
   e2e_android_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
-          post-emulator-launch-assemble-command: cd example && flutter build apk
+          post-emulator-launch-assemble-command: cd "example" && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
       - android/run-tests:
@@ -168,8 +168,8 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "pixel_4"
-          post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
-          test-command: cd e2e || true && dotnet test
+          post-emulator-launch-assemble-command: cd "example" || true && flutter build apk --debug
+          test-command: cd "e2e" || true && dotnet test
 
   test_ios:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,43 +287,44 @@ workflows:
   version: 2
   build-test-and-approval-deploy:
     jobs:
-      - danger:
-          requires:
-            - test_flutter-stable
-      - test_flutter:
-          name: test_flutter-stable
-          version: stable
-      - test_flutter:
-          name: test_flutter-2.10.5
-          version: 2.10.5
       - test_android
-      # - e2e_android_captain
-      # - test_ios
-      # - e2e_ios_captain
-      - format_flutter
-      - lint_flutter:
-          requires:
-            - format_flutter
-      - verify_pub:
-          requires:
-            - lint_flutter
-      - hold_release:
-          type: approval
-          requires:
-            - danger
-            - test_flutter-stable
-            - test_flutter-2.10.5
-            - test_android
-            - e2e_android_captain
-            - test_ios
-            - e2e_ios_captain
-            - verify_pub
-          filters:
-            branches:
-              only: master
-      - release:
-          requires:
-            - hold_release
-          filters:
-            branches:
-              only: master
+#      - danger:
+#          requires:
+#            - test_flutter-stable
+#      - test_flutter:
+#          name: test_flutter-stable
+#          version: stable
+#      - test_flutter:
+#          name: test_flutter-2.10.5
+#          version: 2.10.5
+#      - test_android
+#      - e2e_android_captain
+#      - test_ios
+#      - e2e_ios_captain
+#      - format_flutter
+#      - lint_flutter:
+#          requires:
+#            - format_flutter
+#      - verify_pub:
+#          requires:
+#            - lint_flutter
+#      - hold_release:
+#          type: approval
+#          requires:
+#            - danger
+#            - test_flutter-stable
+#            - test_flutter-2.10.5
+#            - test_android
+#            - e2e_android_captain
+#            - test_ios
+#            - e2e_ios_captain
+#            - verify_pub
+#          filters:
+#            branches:
+#              only: master
+#      - release:
+#          requires:
+#            - hold_release
+#          filters:
+#            branches:
+#              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,12 +146,6 @@ jobs:
       - checkout
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          # system-image: system-images;android-29;default;x86
-#          additional-avd-args: -d "Nexus 5"
-          post-emulator-launch-assemble-command: cd example && flutter build apk
-          run-tests-working-directory: example/android
-          test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
-      - android/start-emulator-and-run-tests:
           run-tests-working-directory: example/android
           test-command: ./gradlew test
 
@@ -284,43 +278,43 @@ workflows:
   build-test-and-approval-deploy:
     jobs:
       - test_android
-#      - danger:
-#          requires:
-#            - test_flutter-stable
-#      - test_flutter:
-#          name: test_flutter-stable
-#          version: stable
-#      - test_flutter:
-#          name: test_flutter-2.10.5
-#          version: 2.10.5
-#      - test_android
-#      - e2e_android_captain
-#      - test_ios
-#      - e2e_ios_captain
-#      - format_flutter
-#      - lint_flutter:
-#          requires:
-#            - format_flutter
-#      - verify_pub:
-#          requires:
-#            - lint_flutter
-#      - hold_release:
-#          type: approval
-#          requires:
-#            - danger
-#            - test_flutter-stable
-#            - test_flutter-2.10.5
-#            - test_android
-#            - e2e_android_captain
-#            - test_ios
-#            - e2e_ios_captain
-#            - verify_pub
-#          filters:
-#            branches:
-#              only: master
-#      - release:
-#          requires:
-#            - hold_release
-#          filters:
-#            branches:
-#              only: master
+      - danger:
+          requires:
+            - test_flutter-stable
+      - test_flutter:
+          name: test_flutter-stable
+          version: stable
+      - test_flutter:
+          name: test_flutter-2.10.5
+          version: 2.10.5
+      - test_android
+      - e2e_android_captain
+      - test_ios
+      - e2e_ios_captain
+      - format_flutter
+      - lint_flutter:
+          requires:
+            - format_flutter
+      - verify_pub:
+          requires:
+            - lint_flutter
+      - hold_release:
+          type: approval
+          requires:
+            - danger
+            - test_flutter-stable
+            - test_flutter-2.10.5
+            - test_android
+            - e2e_android_captain
+            - test_ios
+            - e2e_ios_captain
+            - verify_pub
+          filters:
+            branches:
+              only: master
+      - release:
+          requires:
+            - hold_release
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,11 +142,12 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
+    working_directory: ~/project/examples/
     steps:
       - checkout
       - setup_flutter
-      - android/start-emulator-and-run-tests:
-          run-tests-working-directory: example/android
+      - android/run-tests:
+          working-directory: android
           test-command: ./gradlew test
 
   e2e_android_captain:
@@ -159,16 +160,21 @@ jobs:
       - setup_captain:
           platform: android
       - setup_flutter
+      - run:
+          name: Build Example App
+          working_directory: example
+          command: flutter build apk --denug
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-29;default;x86
-          #          additional-avd-args: -d "pixel_4"
-          post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
-          test-command: cd e2e || true && dotnet test
+          working-directory: e2e
+          test-command: dotnet test
 
   test_ios:
     macos:
       xcode: 13.4.1
     resource_class: macos.m1.medium.gen1
+    working_directory: ~/project/examples/
+    environment:
+      INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
       - checkout
       - setup_ios
@@ -177,11 +183,12 @@ jobs:
           working_directory: example/ios
           command: |
             xcodebuild -allowProvisioningUpdates \
-                       -workspace Runner.xcworkspace \
-                       -scheme Runner \
-                       -sdk iphonesimulator \
-                       -destination 'name=iPhone 12 Pro Max' \
-                       test | xcpretty
+                -workspace InstabugExample.xcworkspace \
+                -scheme InstabugExample \
+                -resultBundlePath coverage/result.xcresult \
+                -sdk iphonesimulator \
+                -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max,OS=15.5' \
+                test | xcpretty
 
   e2e_ios_captain:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,8 @@ jobs:
   test_android:
     executor:
       name: android/android-machine
-      resource-class: xlarge
-      tag: 2024.01.1-ndk
+#      resource-class: xlarge
+#      tag: 2024.01.1-ndk
     steps:
       - checkout
       - setup_flutter
@@ -158,8 +158,8 @@ jobs:
   e2e_android_captain:
     executor:
       name: android/android-machine
-      resource-class: xlarge
-      tag: 2024.01.1-ndk
+#      resource-class: xlarge
+#      tag: 2024.01.1-ndk
     steps:
       - checkout
       - setup_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           # system-image: system-images;android-29;default;x86
-          additional-avd-args: -d 'Nexus 5'
+          additional-avd-args: -d Nexus 5
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
-          additional-avd-args: -d "Pixel 4"
+          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
@@ -168,8 +168,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
-          additional-avd-args: -d "Pixel 4"
-#          additional-avd-args: -d "pixel_4"
+          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           run-tests-working-directory: e2e
-          system-image: system-images;android-33;default;x86
+          system-image: system-images;android-33;default;x86_64
           post-emulator-launch-assemble-command: cd example && flutter build apk --debug
           test-command: dotnet test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,8 @@ jobs:
           name: Build Example App
           working_directory: example
           command: flutter build apk --debug
-      - android/run-tests:
-          working-directory: e2e
+      - android/start-emulator-and-run-tests:
+          run-tests-working-directory: e2e
           test-command: dotnet test
 
   test_ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,8 @@ jobs:
     steps:
       - checkout
       - setup_flutter
-      - android/start-emulator-and-run-tests:
+      -
+      - android/run-ui-tests:
           # system-image: system-images;android-29;default;x86
 #          additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           run-tests-working-directory: e2e
-          post-emulator-launch-assemble-command: cd ../example && flutter build apk --debug
+          post-emulator-launch-assemble-command: cd example && flutter build apk --debug
           test-command: dotnet test
 
   test_ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - checkout
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86_64
+          system-image: system-images;android-29;default;x86
           # additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
@@ -165,8 +165,8 @@ jobs:
       - setup_captain:
           platform: android
       - setup_flutter
-      - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86_64
+      - android/run-ui-tests:
+          system-image: system-images;android-29;default;x86
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
-          additional-avd-args: -d "Pixel 4 API 33"
+          additional-avd-args: -d "Pixel 4"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
@@ -168,7 +168,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
-          additional-avd-args: -d "Pixel 4 API 33"
+          additional-avd-args: -d "Pixel 4"
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,13 +160,9 @@ jobs:
       - setup_captain:
           platform: android
       - setup_flutter
-      - run:
-          name: Build Example App
-          working_directory: example
-          command: flutter build apk --debug
       - android/start-emulator-and-run-tests:
           run-tests-working-directory: e2e
-          post-emulator-launch-assemble-command:
+          post-emulator-launch-assemble-command: cd ../example && flutter build apk --debug
           test-command: dotnet test
 
   test_ios:
@@ -187,7 +183,7 @@ jobs:
                 -scheme Runner \
                 -resultBundlePath coverage/result.xcresult \
                 -sdk iphonesimulator \
-                -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max,OS=15.5' \
+                -destination 'platform=iOS Simulator,name=iPhone 15 Pro Max,OS=17.4' \
                 test | xcpretty
 
   e2e_ios_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           # system-image: system-images;android-29;default;x86
-          additional-avd-args: -d Nexus 5
+#          additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,13 +145,13 @@ jobs:
     steps:
       - checkout
       - setup_flutter
-      - android/run-ui-tests:
+      - android/start-emulator-and-run-tests:
           # system-image: system-images;android-29;default;x86
 #          additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
-      - android/run-tests:
+      - android/start-emulator-and-run-tests:
           working-directory: example/android
           test-command: ./gradlew test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,8 @@ jobs:
   test_android:
     executor:
       name: android/android-machine
-#      resource-class: xlarge
-      tag: 2024.01.1-ndk
+      resource-class: xlarge
+      tag: 2024.01.1
     steps:
       - checkout
       - setup_flutter
@@ -158,8 +158,8 @@ jobs:
   e2e_android_captain:
     executor:
       name: android/android-machine
-#      resource-class: xlarge
-      tag: 2024.01.1-ndk
+      resource-class: xlarge
+      tag: 2024.01.1
     steps:
       - checkout
       - setup_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: circleci/android@2.5.0
+  android: circleci/android@2.4.0
   flutter: circleci/flutter@2.0.2
   node: circleci/node@5.2.0
 
@@ -165,7 +165,7 @@ jobs:
       - setup_captain:
           platform: android
       - setup_flutter
-      - android/run-ui-tests:
+      - android/start-emulator-and-run-tests:
           system-image: system-images;android-29;default;x86
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
       - android/start-emulator-and-run-tests:
-          working-directory: example/android
+          run-tests-working-directory: example/android
           test-command: ./gradlew test
 
   e2e_android_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,6 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
-    working_directory: ~/project/examples/
     steps:
       - advanced-checkout/shallow-checkout
       - setup_flutter
@@ -173,7 +172,6 @@ jobs:
     macos:
       xcode: 13.4.1
     resource_class: macos.m1.medium.gen1
-    working_directory: ~/project/examples/
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
@@ -181,7 +179,7 @@ jobs:
       - setup_ios
       - run:
           name: Build and run tests
-          working_directory: ios
+          working_directory:  ~/project/examples/ios
           command: |
             xcodebuild -allowProvisioningUpdates \
                 -workspace InstabugExample.xcworkspace \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           # system-image: system-images;android-29;default;x86
-          additional-avd-args: -d "Nexus 5"
+          additional-avd-args: -d 'Nexus 5'
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
-          post-emulator-launch-assemble-command: cd "example" && flutter build apk
+          post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
       - android/run-tests:
@@ -168,8 +168,8 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "pixel_4"
-          post-emulator-launch-assemble-command: cd "example" || true && flutter build apk --debug
-          test-command: cd "e2e" || true && dotnet test
+          post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
+          test-command: cd e2e || true && dotnet test
 
   test_ios:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     executor:
       name: android/android-machine
 #      resource-class: xlarge
-#      tag: 2024.01.1-ndk
+      tag: 2024.01.1-ndk
     steps:
       - checkout
       - setup_flutter
@@ -159,7 +159,7 @@ jobs:
     executor:
       name: android/android-machine
 #      resource-class: xlarge
-#      tag: 2024.01.1-ndk
+      tag: 2024.01.1-ndk
     steps:
       - checkout
       - setup_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
+          additional-avd-args: -d "Pixel 4 API 33"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
@@ -167,7 +168,8 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
-          # additional-avd-args: -d "pixel_4"
+          additional-avd-args: -d "Pixel 4 API 33"
+#          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
     executor:
       name: node/default
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - node/install-packages:
           pkg-manager: yarn
           override-ci-command: yarn install --frozen-lockfile --network-concurrency 1
@@ -125,7 +125,7 @@ jobs:
     docker:
       - image: cirrusci/flutter:<<parameters.version>>
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - install_flutter_and_dart_packages:
           generate_pigeons: true
       - run: flutter test --coverage
@@ -144,10 +144,10 @@ jobs:
       tag: default
     working_directory: ~/project/examples/
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - setup_flutter
       - android/run-tests:
-          working-directory: android
+          working-directory: ~/project/examples/android
           test-command: ./gradlew test
 
   e2e_android_captain:
@@ -156,14 +156,14 @@ jobs:
       resource-class: xlarge
       tag: default
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - setup_captain:
           platform: android
       - setup_flutter
       - run:
           name: Build Example App
           working_directory: example
-          command: flutter build apk --denug
+          command: flutter build apk --debug
       - android/run-tests:
           working-directory: e2e
           test-command: dotnet test
@@ -176,11 +176,11 @@ jobs:
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - setup_ios
       - run:
           name: Build and run tests
-          working_directory: example/ios
+          working_directory: ios
           command: |
             xcodebuild -allowProvisioningUpdates \
                 -workspace InstabugExample.xcworkspace \
@@ -195,7 +195,7 @@ jobs:
       xcode: 13.4.1
     resource_class: macos.m1.medium.gen1
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - setup_captain:
           platform: ios
       - setup_ios
@@ -213,7 +213,7 @@ jobs:
     docker:
       - image: cirrusci/flutter
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - install_flutter_and_dart_packages:
           generate_pigeons: false
       - run:
@@ -224,7 +224,7 @@ jobs:
     docker:
       - image: cirrusci/flutter
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - install_flutter_and_dart_packages:
           generate_pigeons: true
       - run:
@@ -235,7 +235,7 @@ jobs:
     docker:
       - image: cirrusci/flutter
     steps:
-      - checkout
+      - advanced-checkout/shallow-checkout
       - install_flutter_and_dart_packages:
           generate_pigeons: true
       - run:
@@ -249,7 +249,7 @@ jobs:
     resource_class: macos.m1.medium.gen1
     working_directory: "~"
     steps:
-      - checkout:
+      - advanced-checkout/shallow-checkout:
           path: ~/project
       # Flutter doesn't support Apple Silicon yet, so we need to install Rosetta use Flutter on M1 machines.
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           run-tests-working-directory: e2e
+          system-image: system-images;android-33;default;x86
           post-emulator-launch-assemble-command: cd example && flutter build apk --debug
           test-command: dotnet test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
       - setup_ios
       - run:
           name: Build and run tests
-          working_directory:  ~/project/examples/ios
+          working_directory:  ~/project/example/ios
           command: |
             xcodebuild -allowProvisioningUpdates \
                 -workspace InstabugExample.xcworkspace \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,6 @@ jobs:
     steps:
       - checkout
       - setup_flutter
-      -
       - android/run-ui-tests:
           # system-image: system-images;android-29;default;x86
 #          additional-avd-args: -d "Nexus 5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
           name: Build Example App
           working_directory: example
           command: flutter build apk --denug
-      - android/start-emulator-and-run-tests:
+      - android/run-tests:
           working-directory: e2e
           test-command: dotnet test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - checkout
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-34;google_apis;x86_64
+          system-image: system-images;android-33;google_apis;x86_64
           # additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  android: circleci/android@2.0
+  android: circleci/android@2.5.0
   flutter: circleci/flutter@2.0.2
-  node: circleci/node@5.1.0
+  node: circleci/node@5.2.0
 
 commands:
   setup_flutter:
@@ -103,7 +103,6 @@ commands:
                 name: Build Pigeons
                 command: dart run build_runner build --delete-conflicting-outputs
 
-
 jobs:
   danger:
     executor:
@@ -142,7 +141,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: xlarge
-      tag: 2022.04.1
+      tag: 2024.01.1-ndk
     steps:
       - checkout
       - setup_flutter
@@ -160,7 +159,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: xlarge
-      tag: 2022.04.1
+      tag: 2024.01.1-ndk
     steps:
       - checkout
       - setup_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ jobs:
           command: flutter build apk --debug
       - android/start-emulator-and-run-tests:
           run-tests-working-directory: e2e
+          post-emulator-launch-assemble-command:
           test-command: dotnet test
 
   test_ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-29;default;x86
-#          additional-avd-args: -d "pixel_4"
+          #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test
 
@@ -287,7 +287,6 @@ workflows:
       - test_flutter:
           name: test_flutter-2.10.5
           version: 2.10.5
-      - test_android
       - e2e_android_captain
       - test_ios
       - e2e_ios_captain

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,9 +146,8 @@ jobs:
       - checkout
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86
+          system-image: system-images;android-34;google_apis;x86_64
           # additional-avd-args: -d "Nexus 5"
-#          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
@@ -167,7 +166,7 @@ jobs:
           platform: android
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-33;google_apis;x86
+          system-image: system-images;android-33;google_apis;x86_64
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - checkout
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-30;google_apis;x86
+          system-image: system-images;android-33;google_apis;x86
           # additional-avd-args: -d "Nexus 5"
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example && flutter build apk
@@ -167,7 +167,7 @@ jobs:
           platform: android
       - setup_flutter
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-30;google_apis;x86
+          system-image: system-images;android-33;google_apis;x86
 #          additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: xlarge
-      tag: 2024.01.1
+      tag: default
     steps:
       - checkout
       - setup_flutter
@@ -159,7 +159,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: xlarge
-      tag: 2024.01.1
+      tag: default
     steps:
       - checkout
       - setup_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
-          additional-avd-args: -d "Nexus 5"
+          # additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart
@@ -167,7 +167,7 @@ jobs:
       - setup_flutter
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;google_apis;x86
-          additional-avd-args: -d "pixel_4"
+          # additional-avd-args: -d "pixel_4"
           post-emulator-launch-assemble-command: cd example || true && flutter build apk --debug
           test-command: cd e2e || true && dotnet test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  android: circleci/android@2.4.0
+  android: circleci/android@2.5.0
   flutter: circleci/flutter@2.0.2
   node: circleci/node@5.2.0
 
@@ -145,13 +145,9 @@ jobs:
     steps:
       - checkout
       - setup_flutter
-      - android/create-avd:
-            avd-name: testavd
-            install: true
-            system-image: system-images;android-29;default;x86
       - android/start-emulator-and-run-tests:
-          system-image: testavd
-          # additional-avd-args: -d "Nexus 5"
+          # system-image: system-images;android-29;default;x86
+          additional-avd-args: -d "Nexus 5"
           post-emulator-launch-assemble-command: cd example && flutter build apk
           run-tests-working-directory: example/android
           test-command: ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../test_driver/example.dart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
 
   test_ios:
     macos:
-      xcode: 13.4.1
+      xcode: 15.3.0
     resource_class: macos.m1.medium.gen1
     environment:
       INSTABUG_SOURCEMAPS_UPLOAD_DISABLE: true
@@ -192,7 +192,7 @@ jobs:
 
   e2e_ios_captain:
     macos:
-      xcode: 13.4.1
+      xcode: 15.3.0
     resource_class: macos.m1.medium.gen1
     steps:
       - advanced-checkout/shallow-checkout
@@ -245,7 +245,7 @@ jobs:
 
   release:
     macos:
-      xcode: 13.4.1
+      xcode: 15.3.0
     resource_class: macos.m1.medium.gen1
     working_directory: "~"
     steps:

--- a/e2e/Utils/CaptainTest.cs
+++ b/e2e/Utils/CaptainTest.cs
@@ -9,7 +9,7 @@ public class CaptainTest : IDisposable
   {
     AndroidApp = Path.GetFullPath("../../../../example/build/app/outputs/flutter-apk/app-debug.apk"),
     AndroidAppId = "com.instabug.flutter.example",
-    AndroidVersion = "13",
+    AndroidVersion = "11",
     IosApp = Path.GetFullPath("../../../../example/build/ios/iphonesimulator/Runner.app"),
     IosAppId = "com.instabug.InstabugSample",
     IosVersion = "15.5",

--- a/e2e/Utils/CaptainTest.cs
+++ b/e2e/Utils/CaptainTest.cs
@@ -12,8 +12,8 @@ public class CaptainTest : IDisposable
     AndroidVersion = "11",
     IosApp = Path.GetFullPath("../../../../example/build/ios/iphonesimulator/Runner.app"),
     IosAppId = "com.instabug.InstabugSample",
-    IosVersion = "15.5",
-    IosDevice = "iPhone 13 Pro Max"
+    IosVersion = "17.4",
+    IosDevice = "iPhone 15 Pro Max"
   };
   protected static readonly Captain captain = new(_config);
 

--- a/e2e/Utils/CaptainTest.cs
+++ b/e2e/Utils/CaptainTest.cs
@@ -9,7 +9,7 @@ public class CaptainTest : IDisposable
   {
     AndroidApp = Path.GetFullPath("../../../../example/build/app/outputs/flutter-apk/app-debug.apk"),
     AndroidAppId = "com.instabug.flutter.example",
-    AndroidVersion = "11",
+    AndroidVersion = "13",
     IosApp = Path.GetFullPath("../../../../example/build/ios/iphonesimulator/Runner.app"),
     IosAppId = "com.instabug.InstabugSample",
     IosVersion = "17.4",

--- a/e2e/Utils/CaptainTest.cs
+++ b/e2e/Utils/CaptainTest.cs
@@ -9,7 +9,7 @@ public class CaptainTest : IDisposable
   {
     AndroidApp = Path.GetFullPath("../../../../example/build/app/outputs/flutter-apk/app-debug.apk"),
     AndroidAppId = "com.instabug.flutter.example",
-    AndroidVersion = "11",
+    AndroidVersion = "13",
     IosApp = Path.GetFullPath("../../../../example/build/ios/iphonesimulator/Runner.app"),
     IosAppId = "com.instabug.InstabugSample",
     IosVersion = "15.5",


### PR DESCRIPTION
## Description of the change
> upgrade android orb from 2.0 to 2.5.0 (latest).
 upgrade node orbe from 5.1.0 to 5.2.0 (latest).
 upgrade the deprecated android image 2022.04.1 to 2024.01.1-ndk
 
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> MOB-14216
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
