### PR TITLE
feat: sanitize the Screen name before reporting

### DIFF
--- a/lib/src/utils/screen_loading/instabug_capture_screen_loading.dart
+++ b/lib/src/utils/screen_loading/instabug_capture_screen_loading.dart
@@ -31,7 +31,7 @@ class _InstabugCaptureScreenLoadingState
   void initState() {
     super.initState();
     trace = ScreenLoadingTrace(
-      widget.screenName,
+      ScreenLoadingManager.I.sanitizeScreenName(widget.screenName),
       startTimeInMicroseconds: startTimeInMicroseconds,
       startMonotonicTimeInMicroseconds: startMonotonicTimeInMicroseconds,
     );

--- a/lib/src/utils/screen_loading/screen_loading_manager.dart
+++ b/lib/src/utils/screen_loading/screen_loading_manager.dart
@@ -95,6 +95,36 @@ class ScreenLoadingManager {
     );
   }
 
+  /// The function `sanitizeScreenName` removes leading and trailing slashes from a screen name in Dart.
+  ///
+  /// Args:
+  ///   screenName (String): The `sanitizeScreenName` function is designed to remove a specific character
+  /// ('/') from the beginning and end of a given `screenName` string. If the `screenName` is equal to
+  /// '/', it will return 'ROOT_PAGE'. Otherwise, it will remove the character from the beginning and end
+  /// if
+  ///
+  /// Returns:
+  ///   The `sanitizeScreenName` function returns the sanitized screen name after removing any leading or
+  /// trailing '/' characters. If the input `screenName` is equal to '/', it returns 'ROOT_PAGE'.
+
+  @internal
+  String sanitizeScreenName(String screenName) {
+    const characterToBeRemoved = '/';
+    final lastIndex = screenName.length - 1;
+    var sanitizedScreenName = screenName;
+
+    if (screenName == characterToBeRemoved) {
+      return 'ROOT_PAGE';
+    }
+    if (screenName[0] == characterToBeRemoved) {
+      sanitizedScreenName = sanitizedScreenName.substring(1);
+    }
+    if (screenName[lastIndex] == characterToBeRemoved) {
+      sanitizedScreenName = sanitizedScreenName.substring(0, lastIndex - 1);
+    }
+    return sanitizedScreenName;
+  }
+
   @internal
   Future<void> startUiTrace(String screenName) async {
     try {
@@ -119,10 +149,11 @@ class ScreenLoadingManager {
         return;
       }
 
+      final sanitizedScreenName = sanitizeScreenName(screenName);
       final microTimeStamp = IBGDateTime.I.now().microsecondsSinceEpoch;
       final uiTraceId = IBGDateTime.I.now().millisecondsSinceEpoch;
-      APM.startCpUiTrace(screenName, microTimeStamp, uiTraceId);
-      currentUiTrace = UiTrace(screenName, traceId: uiTraceId);
+      APM.startCpUiTrace(sanitizedScreenName, microTimeStamp, uiTraceId);
+      currentUiTrace = UiTrace(sanitizedScreenName, traceId: uiTraceId);
     } catch (error, stackTrace) {
       _logExceptionErrorAndStackTrace(error, stackTrace);
     }


### PR DESCRIPTION

sanitize the Screen name before reporting to Native and will remove any leading or trailing '/' and replace the Root route name with ROOT_PAGE if it equals '/'