### PR TITLE
feat: add isEndScreenLoading API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,9 +143,8 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
-      machine:
-        java:
-          version: 'oraclejdk8'
+      java:
+        version: 'oraclejdk8'
     steps:
       - advanced-checkout/shallow-checkout
       - setup_flutter
@@ -158,9 +157,8 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
-      machine:
-        java:
-          version: 'oraclejdk8'
+      java:
+        version: 'oraclejdk8'
     steps:
       - advanced-checkout/shallow-checkout
       - setup_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,8 @@ jobs:
     steps:
       - advanced-checkout/shallow-checkout
       - setup_flutter
+      - android/change-java-version:
+          java-version: 8 
       - android/run-tests:
           working-directory: example/android
           test-command: ./gradlew test
@@ -160,6 +162,8 @@ jobs:
       - setup_captain:
           platform: android
       - setup_flutter
+      - android/change-java-version:
+          java-version: 8 
       - android/start-emulator-and-run-tests:
           run-tests-working-directory: e2e
           additional-avd-args: --device 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,9 +143,9 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
-      java:
-        version: 'oraclejdk8'
     steps:
+      - android/change-java-version:
+          java-version: 8 
       - advanced-checkout/shallow-checkout
       - setup_flutter
       - android/run-tests:
@@ -157,9 +157,9 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
-      java:
-        version: 'oraclejdk8'
     steps:
+      - android/change-java-version:
+          java-version: 8 
       - advanced-checkout/shallow-checkout
       - setup_captain:
           platform: android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,9 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
+      machine:
+        java:
+          version: 'oraclejdk8'
     steps:
       - advanced-checkout/shallow-checkout
       - setup_flutter
@@ -155,6 +158,9 @@ jobs:
       name: android/android-machine
       resource-class: xlarge
       tag: default
+      machine:
+        java:
+          version: 'oraclejdk8'
     steps:
       - advanced-checkout/shallow-checkout
       - setup_captain:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.5.0
-  flutter: circleci/flutter@2.0.2
+  flutter: circleci/flutter@2.0.4
   node: circleci/node@5.2.0
   advanced-checkout: vsco/advanced-checkout@1.1.0
 
@@ -144,8 +144,6 @@ jobs:
       resource-class: xlarge
       tag: default
     steps:
-      - android/change-java-version:
-          java-version: 8 
       - advanced-checkout/shallow-checkout
       - setup_flutter
       - android/run-tests:
@@ -158,8 +156,6 @@ jobs:
       resource-class: xlarge
       tag: default
     steps:
-      - android/change-java-version:
-          java-version: 8 
       - advanced-checkout/shallow-checkout
       - setup_captain:
           platform: android

--- a/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
@@ -1,8 +1,10 @@
 package com.instabug.flutter.modules;
 
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.instabug.apm.APM;
 import com.instabug.apm.InternalAPM;
 import com.instabug.apm.configuration.cp.APMFeature;
@@ -12,7 +14,9 @@ import com.instabug.apm.networking.APMNetworkLogger;
 import com.instabug.flutter.generated.ApmPigeon;
 import com.instabug.flutter.util.Reflection;
 import com.instabug.flutter.util.ThreadManager;
+
 import io.flutter.plugin.common.BinaryMessenger;
+
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 
@@ -219,8 +223,6 @@ public class ApmApi implements ApmPigeon.ApmHostApi {
     }
 
 
-
-
     @Override
     public void startCpUiTrace(@NonNull String screenName, @NonNull Long microTimeStamp, @NonNull Long traceId) {
         try {
@@ -250,16 +252,7 @@ public class ApmApi implements ApmPigeon.ApmHostApi {
 
     @Override
     public void isEndScreenLoadingEnabled(@NonNull ApmPigeon.Result<Boolean> result) {
-        try {
-            InternalAPM._isFeatureEnabledCP(APMFeature.SCREEN_LOADING, "InstabugCaptureScreenLoading", new FeatureAvailabilityCallback() {
-                @Override
-                public void invoke(boolean isFeatureAvailable) {
-                    result.success(isFeatureAvailable);
-                }
-            });
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        isScreenLoadingEnabled(result);
     }
 
     @Override

--- a/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/ApmApi.java
@@ -249,6 +249,20 @@ public class ApmApi implements ApmPigeon.ApmHostApi {
     }
 
     @Override
+    public void isEndScreenLoadingEnabled(@NonNull ApmPigeon.Result<Boolean> result) {
+        try {
+            InternalAPM._isFeatureEnabledCP(APMFeature.SCREEN_LOADING, "InstabugCaptureScreenLoading", new FeatureAvailabilityCallback() {
+                @Override
+                public void invoke(boolean isFeatureAvailable) {
+                    result.success(isFeatureAvailable);
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
     public void isEnabled(@NonNull ApmPigeon.Result<Boolean> result) {
         try {
             // TODO: replace true with an actual implementation of APM.isEnabled once implemented

--- a/example/ios/InstabugTests/ApmApiTests.m
+++ b/example/ios/InstabugTests/ApmApiTests.m
@@ -81,6 +81,23 @@
     [self waitForExpectations:@[expectation] timeout:5.0];
 }
 
+- (void)testIsEndScreenLoadingEnabled {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Call completion handler"];
+
+    BOOL isEndScreenLoadingEnabled = YES;
+    OCMStub([self.mAPM endScreenLoadingEnabled]).andReturn(isEndScreenLoadingEnabled);
+
+    [self.api isEndScreenLoadingEnabledWithCompletion:^(NSNumber *isEnabledNumber, FlutterError *error) {
+        [expectation fulfill];
+        
+        XCTAssertEqualObjects(isEnabledNumber, @(isEndScreenLoadingEnabled));
+        
+        XCTAssertNil(error);
+    }];
+
+    [self waitForExpectations:@[expectation] timeout:5.0];
+}
+
 - (void)testSetColdAppLaunchEnabled {
     NSNumber *isEnabled = @1;
     FlutterError *error;

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -30,7 +30,7 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-  pod 'Instabug', :podspec => 'https://ios-releases.instabug.com/custom/fix-duration-negative-value/13.0.0/Instabug.podspec'
+  pod 'Instabug', :podspec => 'https://ios-releases.instabug.com/custom/feature-flutter-screenloading/13.1.0/Instabug.podspec'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,12 +18,12 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.6
+  http: ^0.13.0
   instabug_flutter:
     path: ../
 

--- a/ios/Classes/Modules/ApmApi.m
+++ b/ios/Classes/Modules/ApmApi.m
@@ -124,5 +124,11 @@ NSMutableDictionary *traces;
     [IBGAPM endScreenLoadingCPWithEndTimestampMUS:endScreenLoadingCPWithEndTimestampMUS];
 }
 
+- (void)isEndScreenLoadingEnabledWithCompletion:(nonnull void (^)(NSNumber * _Nullable, FlutterError * _Nullable))completion {
+    BOOL isEndScreenLoadingEnabled = IBGAPM.endScreenLoadingEnabled;
+    NSNumber *isEnabledNumber = @(isEndScreenLoadingEnabled);
+    completion(isEnabledNumber, nil);
+}
+
 
 @end

--- a/ios/Classes/Util/NativeUtils/IBGAPM+PrivateAPIs.h
+++ b/ios/Classes/Util/NativeUtils/IBGAPM+PrivateAPIs.h
@@ -1,9 +1,20 @@
+//
+//  IBGAPM+PrivateAPIs.h
+//  Instabug
+//
+//  Created by Yousef Hamza on 9/7/20.
+//  Copyright © 2020 Moataz. All rights reserved.
+//
+
 #import <Instabug/IBGAPM.h>
 #import "IBGTimeIntervalUnits.h"
 
 @interface IBGAPM (PrivateAPIs)
 
 @property (class, atomic, assign) BOOL networkEnabled;
+
+/// `endScreenLoadingEnabled` will be only true if  APM, screenLoadingFeature.enabled and autoUITracesUserPreference are true
+@property (class, atomic, assign) BOOL endScreenLoadingEnabled;
 
 + (void)startUITraceCPWithName:(NSString *)name startTimestampMUS:(IBGMicroSecondsTimeInterval)startTimestampMUS;
 

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '13.0.0'
+  s.dependency 'Instabug', '13.1.0'
 end
 

--- a/lib/src/modules/apm.dart
+++ b/lib/src/modules/apm.dart
@@ -218,7 +218,6 @@ class APM {
     return ScreenLoadingManager.I.endScreenLoading();
   }
 
-
   /// @nodoc
   @internal
   static Future<bool> isEndScreenLoadingEnabled() async {

--- a/lib/src/modules/apm.dart
+++ b/lib/src/modules/apm.dart
@@ -217,4 +217,11 @@ class APM {
   static Future<void> endScreenLoading() {
     return ScreenLoadingManager.I.endScreenLoading();
   }
+
+
+  /// @nodoc
+  @internal
+  static Future<bool> isEndScreenLoadingEnabled() async {
+    return _host.isEndScreenLoadingEnabled();
+  }
 }

--- a/lib/src/modules/instabug.dart
+++ b/lib/src/modules/instabug.dart
@@ -9,6 +9,8 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+// to maintain supported versions prior to Flutter 3.3
+// ignore: unused_import
 import 'package:flutter/services.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
 import 'package:instabug_flutter/src/generated/instabug.api.g.dart';

--- a/lib/src/utils/screen_loading/flags_config.dart
+++ b/lib/src/utils/screen_loading/flags_config.dart
@@ -4,6 +4,7 @@ enum FlagsConfig {
   apm,
   uiTrace,
   screenLoading,
+  endScreenLoading,
 }
 
 extension FeatureExtensions on FlagsConfig {
@@ -13,6 +14,8 @@ extension FeatureExtensions on FlagsConfig {
         return APM.isEnabled();
       case FlagsConfig.screenLoading:
         return APM.isScreenLoadingEnabled();
+      case FlagsConfig.endScreenLoading:
+        return APM.isEndScreenLoadingEnabled();
       default:
         return false;
     }

--- a/lib/src/utils/screen_loading/instabug_capture_screen_loading.dart
+++ b/lib/src/utils/screen_loading/instabug_capture_screen_loading.dart
@@ -38,7 +38,9 @@ class _InstabugCaptureScreenLoadingState
 
     ScreenLoadingManager.I.startScreenLoadingTrace(trace!);
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    // to maintain supported versions prior to Flutter 3.0.0
+    // ignore: invalid_null_aware_operator
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       stopwatch.stop();
       final duration = stopwatch.elapsedMicroseconds;
       trace?.duration = duration;

--- a/lib/src/utils/screen_loading/screen_loading_manager.dart
+++ b/lib/src/utils/screen_loading/screen_loading_manager.dart
@@ -174,7 +174,7 @@ class ScreenLoadingManager {
           InstabugLogger.I.e(
             'Screen loading monitoring is disabled, skipping starting screen loading monitoring for screen: ${trace.screenName}.\n'
             'Please refer to the documentation for how to enable screen loading monitoring on your app: '
-            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking '
             "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
             tag: APM.tag,
           );
@@ -227,7 +227,7 @@ class ScreenLoadingManager {
           InstabugLogger.I.e(
             'Screen loading monitoring is disabled, skipping reporting screen loading time for screen: ${trace?.screenName}.\n'
             'Please refer to the documentation for how to enable screen loading monitoring on your app: '
-            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking '
             "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
             tag: APM.tag,
           );
@@ -293,7 +293,7 @@ class ScreenLoadingManager {
           InstabugLogger.I.e(
             'Screen loading monitoring is disabled, skipping ending screen loading monitoring with APM.endScreenLoading().\n'
             'Please refer to the documentation for how to enable screen loading monitoring in your app: '
-            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking '
             "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
             tag: APM.tag,
           );
@@ -309,7 +309,7 @@ class ScreenLoadingManager {
           InstabugLogger.I.e(
             'End Screen loading API is disabled.\n'
             'Please refer to the documentation for how to enable screen loading monitoring in your app: '
-            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking '
             "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
             tag: APM.tag,
           );

--- a/lib/src/utils/screen_loading/screen_loading_manager.dart
+++ b/lib/src/utils/screen_loading/screen_loading_manager.dart
@@ -287,10 +287,27 @@ class ScreenLoadingManager {
 
       final isScreenLoadingEnabled =
           await FlagsConfig.screenLoading.isEnabled();
+
       if (!isScreenLoadingEnabled) {
         if (IBGBuildInfo.I.isIOS) {
           InstabugLogger.I.e(
             'Screen loading monitoring is disabled, skipping ending screen loading monitoring with APM.endScreenLoading().\n'
+            'Please refer to the documentation for how to enable screen loading monitoring in your app: '
+            'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+            "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
+            tag: APM.tag,
+          );
+        }
+        return;
+      }
+
+      final isEndScreenLoadingEnabled =
+          await FlagsConfig.endScreenLoading.isEnabled();
+
+      if (!isEndScreenLoadingEnabled) {
+        if (IBGBuildInfo.I.isIOS) {
+          InstabugLogger.I.e(
+            'End Screen loading API is disabled.\n'
             'Please refer to the documentation for how to enable screen loading monitoring in your app: '
             'https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
             "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",

--- a/pigeons/apm.api.dart
+++ b/pigeons/apm.api.dart
@@ -37,4 +37,7 @@ abstract class ApmHostApi {
   );
 
   void endScreenLoadingCP(int timeStampMicro, int uiTraceId);
+
+  @async
+  bool isEndScreenLoadingEnabled();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,5 +34,5 @@ flutter:
         pluginClass: InstabugFlutterPlugin
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/test/apm_test.dart
+++ b/test/apm_test.dart
@@ -249,4 +249,13 @@ void main() {
     ).called(1);
     verifyNoMoreInteractions(mHost);
   });
+
+  test('[isSEndScreenLoadingEnabled] should call host method', () async {
+    when(mHost.isEndScreenLoadingEnabled()).thenAnswer((_) async => true);
+    await APM.isEndScreenLoadingEnabled();
+
+    verify(
+      mHost.isEndScreenLoadingEnabled(),
+    ).called(1);
+  });
 }

--- a/test/utils/screen_loading/screen_loading_manager_test.dart
+++ b/test/utils/screen_loading/screen_loading_manager_test.dart
@@ -14,7 +14,6 @@ import 'package:instabug_flutter/src/utils/screen_loading/screen_loading_trace.d
 import 'package:instabug_flutter/src/utils/screen_loading/ui_trace.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-
 import 'screen_loading_manager_test.mocks.dart';
 
 class ScreenLoadingManagerNoResets extends ScreenLoadingManager {
@@ -302,7 +301,7 @@ void main() {
       verify(
         mInstabugLogger.e(
           'Screen loading monitoring is disabled, skipping starting screen loading monitoring for screen: $screenName.\n'
-          'Please refer to the documentation for how to enable screen loading monitoring on your app: https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+          'Please refer to the documentation for how to enable screen loading monitoring on your app: https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking '
           "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
           tag: APM.tag,
         ),
@@ -491,7 +490,7 @@ void main() {
       verify(
         mInstabugLogger.e(
           'Screen loading monitoring is disabled, skipping reporting screen loading time for screen: $screenName.\n'
-          'Please refer to the documentation for how to enable screen loading monitoring on your app: https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+          'Please refer to the documentation for how to enable screen loading monitoring on your app: https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking '
           "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
           tag: APM.tag,
         ),
@@ -776,7 +775,7 @@ void main() {
       verify(
         mInstabugLogger.e(
           'Screen loading monitoring is disabled, skipping ending screen loading monitoring with APM.endScreenLoading().\n'
-          'Please refer to the documentation for how to enable screen loading monitoring in your app: https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking'
+          'Please refer to the documentation for how to enable screen loading monitoring in your app: https://docs.instabug.com/docs/flutter-apm-screen-loading#disablingenabling-screen-loading-tracking '
           "If Screen Loading is enabled but you're still seeing this message, please reach out to support.",
           tag: APM.tag,
         ),
@@ -885,7 +884,7 @@ void main() {
           .thenAnswer((_) async => true);
       when(IBGBuildInfo.I.isIOS).thenReturn(false);
       when(mDateTime.now()).thenReturn(time);
-      final startMonotonicTime = 250;
+      const startMonotonicTime = 250;
       mScreenLoadingManager.currentScreenLoadingTrace
           ?.startMonotonicTimeInMicroseconds = startMonotonicTime;
 
@@ -910,9 +909,12 @@ void main() {
         true,
       );
       verify(mApmHost.isScreenLoadingEnabled()).called(1);
-      verify(mApmHost.endScreenLoadingCP(
-              extendedEndTimeInMicroseconds, uiTrace.traceId))
-          .called(1);
+      verify(
+        mApmHost.endScreenLoadingCP(
+          extendedEndTimeInMicroseconds,
+          uiTrace.traceId,
+        ),
+      ).called(1);
     });
   });
 }

--- a/test/utils/screen_loading/screen_loading_manager_test.dart
+++ b/test/utils/screen_loading/screen_loading_manager_test.dart
@@ -881,6 +881,7 @@ void main() {
 
     test('[endScreenLoading] should End screen loading', () async {
       when(FlagsConfig.screenLoading.isEnabled()).thenAnswer((_) async => true);
+      when(FlagsConfig.endScreenLoading.isEnabled()).thenAnswer((_) async => true);
       when(IBGBuildInfo.I.isIOS).thenReturn(false);
       when(mDateTime.now()).thenReturn(time);
       final startMonotonicTime = 250;

--- a/test/utils/screen_loading/screen_loading_manager_test.dart
+++ b/test/utils/screen_loading/screen_loading_manager_test.dart
@@ -806,13 +806,11 @@ void main() {
         () async {
       uiTrace.didExtendScreenLoading = true;
       when(FlagsConfig.screenLoading.isEnabled()).thenAnswer((_) async => true);
+      when(FlagsConfig.endScreenLoading.isEnabled())
+          .thenAnswer((_) async => true);
       when(IBGBuildInfo.I.isIOS).thenReturn(false);
 
       await ScreenLoadingManager.I.endScreenLoading();
-
-      final actualUiTrace = ScreenLoadingManager.I.currentUiTrace;
-      final actualScreenLoadingTrace =
-          ScreenLoadingManager.I.currentScreenLoadingTrace;
 
       verify(
         mInstabugLogger.e(
@@ -828,6 +826,8 @@ void main() {
       uiTrace.didStartScreenLoading = false;
       mScreenLoadingManager.currentScreenLoadingTrace = null;
       when(FlagsConfig.screenLoading.isEnabled()).thenAnswer((_) async => true);
+      when(FlagsConfig.endScreenLoading.isEnabled())
+          .thenAnswer((_) async => true);
       when(IBGBuildInfo.I.isIOS).thenReturn(false);
 
       await ScreenLoadingManager.I.endScreenLoading();
@@ -857,13 +857,13 @@ void main() {
       const prematureDuration = 0;
       mScreenLoadingManager.currentScreenLoadingTrace = screenLoadingTrace;
       when(FlagsConfig.screenLoading.isEnabled()).thenAnswer((_) async => true);
+      when(FlagsConfig.endScreenLoading.isEnabled())
+          .thenAnswer((_) async => true);
       when(IBGBuildInfo.I.isIOS).thenReturn(false);
 
       await ScreenLoadingManager.I.endScreenLoading();
 
       final actualUiTrace = ScreenLoadingManager.I.currentUiTrace;
-      final actualScreenLoadingTrace =
-          ScreenLoadingManager.I.currentScreenLoadingTrace;
 
       expect(
         actualUiTrace?.didExtendScreenLoading,
@@ -881,7 +881,8 @@ void main() {
 
     test('[endScreenLoading] should End screen loading', () async {
       when(FlagsConfig.screenLoading.isEnabled()).thenAnswer((_) async => true);
-      when(FlagsConfig.endScreenLoading.isEnabled()).thenAnswer((_) async => true);
+      when(FlagsConfig.endScreenLoading.isEnabled())
+          .thenAnswer((_) async => true);
       when(IBGBuildInfo.I.isIOS).thenReturn(false);
       when(mDateTime.now()).thenReturn(time);
       final startMonotonicTime = 250;


### PR DESCRIPTION
## Description of the change
Add [isEndScreenLoading] API to APM module which checks for endScreenLoading feature flag in native.

Note: in android the api to the same as [isScreenLoadingEnabled] API.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
