### PR TITLE
chore(android): bump SDK to v13.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,131 +1,186 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v13.0.0...dev)
+
+### Changed
+
+- Bump Instabug Android SDK to v13.1.1 ([#473](https://github.com/Instabug/Instabug-Flutter/pull/473)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.1.1).
+
+
 ## [13.0.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.7.0...dev) (April 29, 2024)
 
 ### Added
 
 - Adds custom app rating api ([#453](https://github.com/Instabug/Instabug-Flutter/pull/453))
-- Add `SessionReplay.getSessionReplayLink` API which retrieves the current session's replay link ([#445](https://github.com/Instabug/Instabug-Flutter/pull/445)).
-- Add support for App Flows APIs `APM.startFlow`, `APM.endFlow` and `APM.setFlowAttribute` ([#446](https://github.com/Instabug/Instabug-Flutter/pull/446)).
+- Add `SessionReplay.getSessionReplayLink` API which retrieves the current session's replay
+  link ([#445](https://github.com/Instabug/Instabug-Flutter/pull/445)).
+- Add support for App Flows APIs `APM.startFlow`, `APM.endFlow`
+  and `APM.setFlowAttribute` ([#446](https://github.com/Instabug/Instabug-Flutter/pull/446)).
 
 ### Deprecated
 
-- Deprecate execution traces APIs `APM.startExecutionTrace`, `APM.setExecutionTraceAttribute`, `APM.endExecutionTrace`, `Trace.setAttribute` and `Trace.end` in favor of the new app flow APIs ([#446](https://github.com/Instabug/Instabug-Flutter/pull/446)).
+- Deprecate execution traces
+  APIs `APM.startExecutionTrace`, `APM.setExecutionTraceAttribute`, `APM.endExecutionTrace`, `Trace.setAttribute`
+  and `Trace.end` in favor of the new app flow
+  APIs ([#446](https://github.com/Instabug/Instabug-Flutter/pull/446)).
 
 ### Changed
-- Bump Instabug Android SDK to v13.0.0 ([#455](https://github.com/Instabug/Instabug-Flutter/pull/455)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.0.0).
-- Bump Instabug iOS SDK to v13.0.0 ([#446](https://github.com/Instabug/Instabug-Flutter/pull/446)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/13.0.0).
+
+- Bump Instabug Android SDK to
+  v13.0.0 ([#455](https://github.com/Instabug/Instabug-Flutter/pull/455)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.0.0).
+- Bump Instabug iOS SDK to
+  v13.0.0 ([#446](https://github.com/Instabug/Instabug-Flutter/pull/446)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/13.0.0).
 
 ## [12.7.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.5.0...v12.7.0) (February 15, 2024)
 
 ### Added
 
-- Support user identification using ID ([#435](https://github.com/Instabug/Instabug-Flutter/pull/435)).
+- Support user identification using
+  ID ([#435](https://github.com/Instabug/Instabug-Flutter/pull/435)).
 
 ### Changed
 
-- Bump Instabug iOS SDK to v12.7.0 ([#440](https://github.com/Instabug/Instabug-Flutter/pull/440)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/12.7.0).
-- Bump Instabug Android SDK to v12.7.1 ([#439](https://github.com/Instabug/Instabug-Flutter/pull/439)). See release notes for [v12.7.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.7.1).
+- Bump Instabug iOS SDK to
+  v12.7.0 ([#440](https://github.com/Instabug/Instabug-Flutter/pull/440)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/12.7.0).
+- Bump Instabug Android SDK to
+  v12.7.1 ([#439](https://github.com/Instabug/Instabug-Flutter/pull/439)). See release notes
+  for [v12.7.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.7.1).
 
 ## [12.5.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.4.0...v12.5.0) (January 08 , 2024)
 
 ### Changed
 
-- Bump Instabug iOS SDK to v12.5.0 ([#425](https://github.com/Instabug/Instabug-Flutter/pull/425)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/12.5.0).
-- Bump Instabug Android SDK to v12.5.1 ([#426](https://github.com/Instabug/Instabug-Flutter/pull/426)). See release notes for [v12.5.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.5.0) and [v12.5.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.5.1).
+- Bump Instabug iOS SDK to
+  v12.5.0 ([#425](https://github.com/Instabug/Instabug-Flutter/pull/425)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/12.5.0).
+- Bump Instabug Android SDK to
+  v12.5.1 ([#426](https://github.com/Instabug/Instabug-Flutter/pull/426)). See release notes
+  for [v12.5.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.5.0)
+  and [v12.5.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.5.1).
 
 ## [12.4.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.2.0...v12.4.0) (December 13, 2023)
 
 ### Changed
 
-- Bump Instabug iOS SDK to v12.4.0 ([#419](https://github.com/Instabug/Instabug-Flutter/pull/419)). See release notes for [v12.3.0](https://github.com/instabug/instabug-ios/releases/tag/12.3.0) and [v12.4.0](https://github.com/instabug/instabug-ios/releases/tag/12.4.0).
-- Bump Instabug Android SDK to v12.4.1 ([#420](https://github.com/Instabug/Instabug-Flutter/pull/420)). See release notes for [v12.3.0](https://github.com/Instabug/android/releases/tag/v12.3.0), [v12.3.1](https://github.com/Instabug/android/releases/tag/v12.3.1), [v12.4.0](https://github.com/Instabug/android/releases/tag/v12.4.0) and [v12.4.1](https://github.com/Instabug/android/releases/tag/v12.4.1).
+- Bump Instabug iOS SDK to v12.4.0 ([#419](https://github.com/Instabug/Instabug-Flutter/pull/419)).
+  See release notes for [v12.3.0](https://github.com/instabug/instabug-ios/releases/tag/12.3.0)
+  and [v12.4.0](https://github.com/instabug/instabug-ios/releases/tag/12.4.0).
+- Bump Instabug Android SDK to
+  v12.4.1 ([#420](https://github.com/Instabug/Instabug-Flutter/pull/420)). See release notes
+  for [v12.3.0](https://github.com/Instabug/android/releases/tag/v12.3.0), [v12.3.1](https://github.com/Instabug/android/releases/tag/v12.3.1), [v12.4.0](https://github.com/Instabug/android/releases/tag/v12.4.0)
+  and [v12.4.1](https://github.com/Instabug/android/releases/tag/v12.4.1).
 
 ## [12.2.0](https://github.com/Instabug/Instabug-Flutter/compare/12.1.0...12.2.0) (November 16, 2023)
 
 ### Changed
 
-- Bump Instabug iOS SDK to v12.2.0 ([#406](https://github.com/Instabug/Instabug-Flutter/pull/406)). [See release notes](https://github.com/instabug/instabug-ios/releases/tag/12.2.0).
-- Bump Instabug Android SDK to v12.2.0 ([#405](https://github.com/Instabug/Instabug-Flutter/pull/405)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.2.0).
+- Bump Instabug iOS SDK to
+  v12.2.0 ([#406](https://github.com/Instabug/Instabug-Flutter/pull/406)). [See release notes](https://github.com/instabug/instabug-ios/releases/tag/12.2.0).
+- Bump Instabug Android SDK to
+  v12.2.0 ([#405](https://github.com/Instabug/Instabug-Flutter/pull/405)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v12.2.0).
 
 ### Fixed
 
-- Re-enable screenshot capturing for Crash Reporting and Session Replay by removing redundant mapping ([#407](https://github.com/Instabug/Instabug-Flutter/pull/407)).
+- Re-enable screenshot capturing for Crash Reporting and Session Replay by removing redundant
+  mapping ([#407](https://github.com/Instabug/Instabug-Flutter/pull/407)).
 
 ## [12.1.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.14.0...v12.1.0) (September 28, 2023)
 
 ### Added
 
-- Add support for Session Replay, which includes capturing session details, visual reproduction of sessions as well as support for user steps, network and Instabug logs. ([#395](https://github.com/Instabug/Instabug-Flutter/pull/395)).
+- Add support for Session Replay, which includes capturing session details, visual reproduction of
+  sessions as well as support for user steps, network and Instabug
+  logs. ([#395](https://github.com/Instabug/Instabug-Flutter/pull/395)).
 
 ### Changed
 
-- **BREAKING** Remove deprecated APIs ([#385](https://github.com/Instabug/Instabug-Flutter/pull/385)). See migration guide for more details.
-- Bump Instabug iOS SDK to v12.1.0 ([#396](https://github.com/Instabug/Instabug-Flutter/pull/396)). See release notes for [v12.0.0](https://github.com/instabug/instabug-ios/releases/tag/12.0.0) and [v12.1.0](https://github.com/instabug/instabug-ios/releases/tag/12.1.0).
-- Bump Instabug Android SDK to v12.1.0 ([#397](https://github.com/Instabug/Instabug-Flutter/pull/397)). See release notes for [v12.0.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.0.0), [v12.0.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.0.1) and [v12.1.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.1.0).
+- **BREAKING** Remove deprecated
+  APIs ([#385](https://github.com/Instabug/Instabug-Flutter/pull/385)). See migration guide for more
+  details.
+- Bump Instabug iOS SDK to v12.1.0 ([#396](https://github.com/Instabug/Instabug-Flutter/pull/396)).
+  See release notes for [v12.0.0](https://github.com/instabug/instabug-ios/releases/tag/12.0.0)
+  and [v12.1.0](https://github.com/instabug/instabug-ios/releases/tag/12.1.0).
+- Bump Instabug Android SDK to
+  v12.1.0 ([#397](https://github.com/Instabug/Instabug-Flutter/pull/397)). See release notes
+  for [v12.0.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.0.0), [v12.0.1](https://github.com/Instabug/Instabug-Android/releases/tag/v12.0.1)
+  and [v12.1.0](https://github.com/Instabug/Instabug-Android/releases/tag/v12.1.0).
 
 ## [11.14.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.13.0...v11.14.0) (September 13, 2023)
 
 ### Added
 
-- Add network logs obfuscation support using the new `NetworkLogger.obfuscateLog` API ([#380](https://github.com/Instabug/Instabug-Flutter/pull/380)).
-- Add network logs omission support using the new `NetworkLogger.omitLog` API ([#382](https://github.com/Instabug/Instabug-Flutter/pull/382)).
-- Add the new repro steps configuration API `Instabug.setReproStepsConfig` ([#388](https://github.com/Instabug/Instabug-Flutter/pull/388)).
+- Add network logs obfuscation support using the new `NetworkLogger.obfuscateLog`
+  API ([#380](https://github.com/Instabug/Instabug-Flutter/pull/380)).
+- Add network logs omission support using the new `NetworkLogger.omitLog`
+  API ([#382](https://github.com/Instabug/Instabug-Flutter/pull/382)).
+- Add the new repro steps configuration
+  API `Instabug.setReproStepsConfig` ([#388](https://github.com/Instabug/Instabug-Flutter/pull/388)).
 
 ### Changed
 
-- Bump Instabug Android SDK to v11.14.0 ([#384](https://github.com/Instabug/Instabug-Flutter/pull/384)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.14.0).
-- Bump Instabug iOS SDK to v11.14.0 ([#383](https://github.com/Instabug/Instabug-Flutter/pull/383)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.14.0).
+- Bump Instabug Android SDK to
+  v11.14.0 ([#384](https://github.com/Instabug/Instabug-Flutter/pull/384)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.14.0).
+- Bump Instabug iOS SDK to
+  v11.14.0 ([#383](https://github.com/Instabug/Instabug-Flutter/pull/383)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.14.0).
 
 ### Deprecated
 
-- Deprecate `Instabug.setReproStepsMode` in favor of the new `Instabug.setReproStepsConfig` ([#388](https://github.com/Instabug/Instabug-Flutter/pull/388)).
+- Deprecate `Instabug.setReproStepsMode` in favor of the
+  new `Instabug.setReproStepsConfig` ([#388](https://github.com/Instabug/Instabug-Flutter/pull/388)).
 
 ## [11.13.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.12.0...v11.13.0) (July 10, 2023)
 
 ### Changed
 
-- Bump Instabug iOS SDK to v11.13.3 ([#373](https://github.com/Instabug/Instabug-Flutter/pull/373)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/v11.13.0).
-- Bump Instabug Android SDK to v11.13.0 ([#372](https://github.com/Instabug/Instabug-Flutter/pull/372)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.13.0).
+- Bump Instabug iOS SDK to
+  v11.13.3 ([#373](https://github.com/Instabug/Instabug-Flutter/pull/373)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/v11.13.0).
+- Bump Instabug Android SDK to
+  v11.13.0 ([#372](https://github.com/Instabug/Instabug-Flutter/pull/372)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.13.0).
 
 ### Fixed
 
-- Fix an issue that caused APIs that return a value or invoke a callback break on Android in some versions of Flutter ([#370](https://github.com/Instabug/Instabug-Flutter/pull/370), [#369](https://github.com/Instabug/Instabug-Flutter/pull/369)).
+- Fix an issue that caused APIs that return a value or invoke a callback break on Android in some
+  versions of
+  Flutter ([#370](https://github.com/Instabug/Instabug-Flutter/pull/370), [#369](https://github.com/Instabug/Instabug-Flutter/pull/369)).
 
   Below is a list of all the affected APIs:
 
-  - `APM.startExecutionTrace`
-  - `BugReporting.setOnInvokeCallback`
-  - `BugReporting.setOnDismissCallback`
-  - `Instabug.getTags`
-  - `Instabug.getUserAttributeForKey`
-  - `Instabug.getUserAttributes`
-  - `Replies.getUnreadRepliesCount`
-  - `Replies.hasChats`
-  - `Replies.setOnNewReplyReceivedCallback`
-  - `Surveys.hasRespondToSurvey`
-  - `Surveys.setOnShowCallback`
-  - `Surveys.setOnDismissCallback`
+    - `APM.startExecutionTrace`
+    - `BugReporting.setOnInvokeCallback`
+    - `BugReporting.setOnDismissCallback`
+    - `Instabug.getTags`
+    - `Instabug.getUserAttributeForKey`
+    - `Instabug.getUserAttributes`
+    - `Replies.getUnreadRepliesCount`
+    - `Replies.hasChats`
+    - `Replies.setOnNewReplyReceivedCallback`
+    - `Surveys.hasRespondToSurvey`
+    - `Surveys.setOnShowCallback`
+    - `Surveys.setOnDismissCallback`
 
 ## [11.12.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.10.1...v11.12.0) (May 30, 2023)
 
 ### Changed
 
-- Bump Instabug Android SDK to v11.12.0 ([#366](https://github.com/Instabug/Instabug-Flutter/pull/366)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.12.0).
-- Bump Instabug iOS SDK to v11.12.0 ([#365](https://github.com/Instabug/Instabug-Flutter/pull/365)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.12.0).
+- Bump Instabug Android SDK to
+  v11.12.0 ([#366](https://github.com/Instabug/Instabug-Flutter/pull/366)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.12.0).
+- Bump Instabug iOS SDK to
+  v11.12.0 ([#365](https://github.com/Instabug/Instabug-Flutter/pull/365)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.12.0).
 
 ## [11.10.1](https://github.com/Instabug/Instabug-Flutter/compare/v11.10.0...v11.10.1) (April 17, 2023)
 
 ### Changed
 
-- Bump Instabug iOS SDK to v11.10.1 ([#358](https://github.com/Instabug/Instabug-Flutter/pull/358)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.1).
+- Bump Instabug iOS SDK to
+  v11.10.1 ([#358](https://github.com/Instabug/Instabug-Flutter/pull/358)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.1).
 
 ## [11.10.0](https://github.com/Instabug/Instabug-Flutter/compare/v11.9.0...v11.10.0) (April 12, 2023)
 
 ### Changed
 
-- Bump Instabug Android SDK to v11.11.0 ([#352](https://github.com/Instabug/Instabug-Flutter/pull/352)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.11.0).
-- Bump Instabug iOS SDK to v11.10.0 ([#353](https://github.com/Instabug/Instabug-Flutter/pull/353)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.0).
+- Bump Instabug Android SDK to
+  v11.11.0 ([#352](https://github.com/Instabug/Instabug-Flutter/pull/352)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v11.11.0).
+- Bump Instabug iOS SDK to
+  v11.10.0 ([#353](https://github.com/Instabug/Instabug-Flutter/pull/353)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/11.10.0).
 
 ## 11.9.0 (2023-02-21)
 
@@ -141,7 +196,8 @@
   ```
 - Adds `hungarian` and `finnish` locales support.
 - Deprecates `Instabug.start` in favour of `Instabug.init`.
-- Deprecates `Instabug.setDebugEnabled`, `Instabug.setSdkDebugLogsLevel`, and `APM.setLogLevel` in favour of `debugLogsLevel` parameter of `Instabug.init`.
+- Deprecates `Instabug.setDebugEnabled`, `Instabug.setSdkDebugLogsLevel`, and `APM.setLogLevel` in
+  favour of `debugLogsLevel` parameter of `Instabug.init`.
 - Deprecates the `IBGSDKDebugLogsLevel` enum in favour of the `LogLevel` enum.
 - Deprecates both `warning` and `info` values from the `LogLevel` enum.
 - Fixes `norwegian` and `slovak` locales on iOS.
@@ -152,7 +208,8 @@
 
 - Bumps Instabug Android SDK to v11.7.0
 - Bumps Instabug iOS SDK to v11.6.0
-- Adds new string keys: okButtonText, audio, image, screenRecording, messagesNotificationAndOthers, insufficientContentTitle, insufficientContentMessage
+- Adds new string keys: okButtonText, audio, image, screenRecording, messagesNotificationAndOthers,
+  insufficientContentTitle, insufficientContentMessage
 - Fixes APM network logging on Android
 - Fixes a NullPointerException when overriding a string key that doesn't exist on Android
 - Removes redundant native logs
@@ -168,14 +225,17 @@
 - Removes "Media Projection" dialog while taking screenshots on Android
 - Fixes APM network logging on Android
 - Fixes main thread violation on Android
-- Fixes an issue with request and response headers parameters type causing network requests not getting logged on iOS
-- Improves performance by using pigeon for internal communication between Flutter and the host platform
-- Deprecates Instabug.enableAndroid and Instabug.disableAndroid APIs in favour of the new API Instabug.setEnabled, which works on both platforms
+- Fixes an issue with request and response headers parameters type causing network requests not
+  getting logged on iOS
+- Improves performance by using pigeon for internal communication between Flutter and the host
+  platform
+- Deprecates Instabug.enableAndroid and Instabug.disableAndroid APIs in favour of the new API
+  Instabug.setEnabled, which works on both platforms
 - Deprecates callbacks in favor of return values in the following APIs:
-  1. Replies.getUnreadRepliesCount
-  2. Replies.hasChats
-  3. Surveys.hasRespondedToSurvey
-  4. Surveys.getAvailableSurveys
+    1. Replies.getUnreadRepliesCount
+    2. Replies.hasChats
+    3. Surveys.hasRespondedToSurvey
+    4. Surveys.getAvailableSurveys
 
 ## 11.3.0 (2022-09-30)
 
@@ -191,19 +251,24 @@
 - Bumps Instabug Android SDK to v11.4.1
 - Bumps Instabug iOS SDK to v11.2.0
 - Fixes an issue with BugReporting.setInvocationEvents on iOS that always sets the event to none
-- Fixes an issue with network logging on iOS which caused the initial network requests logs to be skipped
+- Fixes an issue with network logging on iOS which caused the initial network requests logs to be
+  skipped
 - Renames Android package from com.instabug.instabugFlutter to com.instabug.flutter
 
 ## v11.0.0 (2022-07-20)
 
 - Bumps Instabug native SDKs to v11
-- Adds the ability to initialize the Android SDK from Dart. Check the migration guide referenced in our docs
-- Changes the package importing style for a more conventional use. Check the migration guide referenced in our docs
-- Moves InstabugCustomHttpClient used for network logging into a separate repo. Check the migration guide referenced in our docs
+- Adds the ability to initialize the Android SDK from Dart. Check the migration guide referenced in
+  our docs
+- Changes the package importing style for a more conventional use. Check the migration guide
+  referenced in our docs
+- Moves InstabugCustomHttpClient used for network logging into a separate repo. Check the migration
+  guide referenced in our docs
 - Flutter 3 compatibility
 - Bumps Gradle to 6.8 & Android Gradle plugin to 4.1
 - Adds BugReporting.setFloatingButtonEdge API
-- Removes the string keys bugReportHeader and feedbackReportHeader. Check the migration guide referenced in our docs
+- Removes the string keys bugReportHeader and feedbackReportHeader. Check the migration guide
+  referenced in our docs
 - Removes the deprecated APIs. Check the migration guide referenced in our docs
 - Fixes an issue with Android screenshots being black on release mode on SDK v10.13.0
 
@@ -257,7 +322,8 @@
 
 ## v9.1.9 (2021-05-11)
 
-- Adds support for overriding the replies notification string values through `repliesNotificationTeamName`, `repliesNotificationReplyButton`, `repliesNotificationDismissButton`
+- Adds support for overriding the replies notification string values
+  through `repliesNotificationTeamName`, `repliesNotificationReplyButton`, `repliesNotificationDismissButton`
 - Removes the use of `android:requestLegacyExternalStorage` attribute on Android
 
 ## v9.1.8 (2021-02-17)
@@ -274,8 +340,10 @@
 ## v9.1.6 (2020-07-13)
 
 - Added CrashReporting
-- Added setShakingThresholdForiPhone, setShakingThresholdForiPad and setShakingThresholdForAndroid APIs
-- Added Proguard rules to protect Flutter bridge class and method names from getting obfuscated when the minifyEnabled flag is set to true.
+- Added setShakingThresholdForiPhone, setShakingThresholdForiPad and setShakingThresholdForAndroid
+  APIs
+- Added Proguard rules to protect Flutter bridge class and method names from getting obfuscated when
+  the minifyEnabled flag is set to true.
 
 ## v9.1.0 (2020-03-19)
 
@@ -291,7 +359,9 @@
 
 ## Version 9.0.1 (2019-12-12)
 
-- Added enum `CustomTextPlaceHolderKey.reportQuestion` which maps to `InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION` on Android and `kIBGAskAQuestionStringName` on iOS
+- Added enum `CustomTextPlaceHolderKey.reportQuestion` which maps
+  to `InstabugCustomTextPlaceHolder.Key.REPORT_QUESTION` on Android and `kIBGAskAQuestionStringName`
+  on iOS
 
 ## Version 9.0.0 (2019-12-09)
 
@@ -316,7 +386,8 @@
 
 ## Version 1.0.0 (2019-07-29)
 
-**⚠️ Package on pub has been renamed to `instabug_flutter` the old package `instabug` is deprecated**
+**⚠️ Package on pub has been renamed to `instabug_flutter` the old package `instabug` is deprecated
+**
 
 ## Version 1.0.0-beta.5 (2019-07-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v13.0.0...dev)
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v13.0.0...dev)
 
 ### Changed
 
-- Bump Instabug Android SDK to v13.1.1 ([#473](https://github.com/Instabug/Instabug-Flutter/pull/473)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.1.1).
+- Bump Instabug Android SDK to v13.1.1 ([#474](https://github.com/Instabug/Instabug-Flutter/pull/474)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.1.1).
 
 
-## [13.0.0](https://github.com/Instabug/Instabug-React-Native/compare/v12.7.0...dev) (April 29, 2024)
+## [13.0.0](https://github.com/Instabug/Instabug-Flutter/compare/v12.7.0...dev) (April 29, 2024)
 
 ### Added
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'com.instabug.library:instabug:13.0.0'
+    api 'com.instabug.library:instabug:13.1.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"


### PR DESCRIPTION
## Description of the change
1. bump android SDK to v13.1.1

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
JIRA ID: MOB-14694
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
