### PR TITLE
chore(ios): bump sdk to v13.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for variants in Feature Flags through the APIs `Instabug.addFeatureFlags`, `Instabug.removeFeatureFlags` and `Instabug.clearAllFeatureFlags` ([#471](https://github.com/Instabug/Instabug-Flutter/pull/471)).
 
+### Changed
+
+- Bump Instabug Android SDK to v13.3.0 ([#492](https://github.com/Instabug/Instabug-Flutter/pull/492)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.3.0).
+
 ### Deprecated
 
 - Deprecate Experiments APIs `Instabug.addExperiments`, `Instabug.removeExperiments` and `Instabug.clearAllExperiments` in favor of the new Feature Flags APIs ([#471](https://github.com/Instabug/Instabug-Flutter/pull/471)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Bump Instabug Android SDK to v13.3.0 ([#492](https://github.com/Instabug/Instabug-Flutter/pull/492)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.3.0).
+- Bump Instabug iOS SDK to v13.3.0 ([#493](https://github.com/Instabug/Instabug-Flutter/pull/493)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/13.3.0).
 
 ### Deprecated
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'com.instabug.library:instabug:13.2.0'
+    api 'com.instabug.library:instabug:13.3.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (13.2.0)
+  - Instabug (13.3.0)
   - instabug_flutter (13.2.0):
     - Flutter
-    - Instabug (= 13.2.0)
+    - Instabug (= 13.3.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -23,11 +23,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/instabug_flutter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Instabug: aee76898789d17c55b36c7fbaa697e443effe3b1
-  instabug_flutter: 8fe63955937c73205d4e71667aea9d56ed8d921b
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Instabug: 4f26295103a330ec0236918359eef7ccaa74e2fa
+  instabug_flutter: 30270796377830845c1f66c6a09d9c897c50133b
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
-PODFILE CHECKSUM: f809f4241ff3da61349081a141c44763598f2fbb
+PODFILE CHECKSUM: 8f7552fd115ace1988c3db54a69e4a123c448f84
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.14.3

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '13.2.0'
+  s.dependency 'Instabug', '13.3.0'
 end
 


### PR DESCRIPTION
## Description of the change

Bump Instabug iOS SDK to v13.3.0.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: MOB-15322
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
