### PR TITLE
test: fix show manual survey e2e test

### DIFF
--- a/e2e/SurveysTests.cs
+++ b/e2e/SurveysTests.cs
@@ -10,7 +10,7 @@ public class SurveysTests : CaptainTest
   [Fact]
   public void ShowManualSurvey()
   {
-    ScrollDown();
+    ScrollDownLittle();
     captain.FindByText("Show Manual Survey").Tap();
 
     captain.WaitForAssertion(() =>


### PR DESCRIPTION
## Description of the change

The "Show Manual Survey" E2E test started to fail due to the over-scrolling causing the "Show Manual Survey" button to not be visible on the screen.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-15324

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
