### PR TITLE
feat: Support enabling NDK crash capturing on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v13.3.0...dev)
+
+### Added
+
+- Support enabling NDK crash capturing on Android ([#501](https://github.com/Instabug/Instabug-React-Native/pull/501)).
+
 ## [13.3.0](https://github.com/Instabug/Instabug-Flutter/compare/v13.2.0...v13.3.0) (August 5, 2024)
 
 ### Added

--- a/android/src/main/java/com/instabug/flutter/modules/CrashReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/CrashReportingApi.java
@@ -51,6 +51,11 @@ public class CrashReportingApi implements CrashReportingPigeon.CrashReportingHos
     }
 
     @Override
+    public void setNDKEnabled(@NonNull Boolean isEnabled) {
+        CrashReporting.setNDKCrashesState(isEnabled ? Feature.State.ENABLED : Feature.State.DISABLED);
+    }
+
+    @Override
     public void sendNonFatalError(@NonNull String jsonCrash, @Nullable Map<String, String> userAttributes, @Nullable String fingerprint, @NonNull String nonFatalExceptionLevel) {
         try {
             Method method = Reflection.getMethod(Class.forName("com.instabug.crash.CrashReporting"), "reportException", JSONObject.class, boolean.class,

--- a/android/src/test/java/com/instabug/flutter/CrashReportingApiTest.java
+++ b/android/src/test/java/com/instabug/flutter/CrashReportingApiTest.java
@@ -98,4 +98,22 @@ public class CrashReportingApiTest {
 
         reflected.verify(() -> MockReflected.crashReportException(any(JSONObject.class), eq(isHandled), eq(expectedUserAttributes), eq(expectedFingerprint), eq(expectedLevel)));
     }
+
+    @Test
+    public void testSetNDKEnabledGivenTrue() {
+        boolean isEnabled = true;
+
+        api.setNDKEnabled(isEnabled);
+
+        mCrashReporting.verify(() -> CrashReporting.setNDKCrashesState(Feature.State.ENABLED));
+    }
+
+    @Test
+    public void testSetNDKEnabledGivenFalse() {
+        boolean isEnabled = false;
+
+        api.setNDKEnabled(isEnabled);
+
+        mCrashReporting.verify(() -> CrashReporting.setNDKCrashesState(Feature.State.DISABLED));
+    }
 }

--- a/ios/Classes/Modules/CrashReportingApi.m
+++ b/ios/Classes/Modules/CrashReportingApi.m
@@ -46,4 +46,9 @@ extern void InitCrashReportingApi(id<FlutterBinaryMessenger> messenger) {
                                              userAttributes:userAttributes];
 
 }
+
+- (void)setNDKEnabledIsEnabled:(nonnull NSNumber *)isEnabled error:(FlutterError * _Nullable __autoreleasing * _Nonnull)error { 
+    
+}
+
 @end

--- a/lib/src/modules/crash_reporting.dart
+++ b/lib/src/modules/crash_reporting.dart
@@ -30,6 +30,13 @@ class CrashReporting {
     return _host.setEnabled(isEnabled);
   }
 
+
+  /// Enables and disables automatic NDK crash reporting on Android.
+  /// [boolean] isEnabled
+  static Future<void> setNDKEnabled(bool isEnabled) async {
+    return _host.setNDKEnabled(isEnabled);
+  }
+
   static Future<void> reportCrash(Object exception, StackTrace stack) async {
     if (IBGBuildInfo.instance.isReleaseMode && enabled) {
       await _reportUnhandledCrash(exception, stack);

--- a/pigeons/crash_reporting.api.dart
+++ b/pigeons/crash_reporting.api.dart
@@ -6,6 +6,8 @@ abstract class CrashReportingHostApi {
 
   void send(String jsonCrash, bool isHandled);
 
+  void setNDKEnabled(bool isEnabled);
+
   void sendNonFatalError(
     String jsonCrash,
     Map<String, String>? userAttributes,

--- a/test/crash_reporting_test.dart
+++ b/test/crash_reporting_test.dart
@@ -37,6 +37,16 @@ void main() {
     ).called(1);
   });
 
+  test('[setNDKEnabled] should call host method', () async {
+    const enabled = true;
+
+    await CrashReporting.setNDKEnabled(enabled);
+
+    verify(
+      mHost.setNDKEnabled(enabled),
+    ).called(1);
+  });
+
   test('[reportHandledCrash] should call host method', () async {
     try {
       final params = <dynamic>[1, 2];


### PR DESCRIPTION
## Description of the change

1. Support enabling NDK crash capturing on Android

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
JIRA ID : 
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
