### PR TITLE
fix: use a fallback for empty screen names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for masking screen names captured by Instabug through the `Instabug.setScreenNameMaskingCallback` API ([#500](https://github.com/Instabug/Instabug-Flutter/pull/500)).
 
+### Fixed
+
+- Fixed an issue with empty screen names captured in `InstabugNavigatorObserver` and fallback to `N/A` when the screen name is empty ([#505](https://github.com/Instabug/Instabug-Flutter/pull/505)), closes [#504](https://github.com/Instabug/Instabug-Flutter/issues/504).
+
 ## [13.3.0](https://github.com/Instabug/Instabug-Flutter/compare/v13.2.0...v13.3.0) (August 5, 2024)
 
 ### Added

--- a/lib/src/utils/instabug_navigator_observer.dart
+++ b/lib/src/utils/instabug_navigator_observer.dart
@@ -3,6 +3,7 @@ import 'package:instabug_flutter/instabug_flutter.dart';
 import 'package:instabug_flutter/src/models/instabug_route.dart';
 import 'package:instabug_flutter/src/modules/instabug.dart';
 import 'package:instabug_flutter/src/utils/instabug_logger.dart';
+import 'package:instabug_flutter/src/utils/repro_steps_constants.dart';
 import 'package:instabug_flutter/src/utils/screen_loading/screen_loading_manager.dart';
 import 'package:instabug_flutter/src/utils/screen_name_masker.dart';
 
@@ -11,7 +12,10 @@ class InstabugNavigatorObserver extends NavigatorObserver {
 
   void screenChanged(Route newRoute) {
     try {
-      final screenName = newRoute.settings.name.toString();
+      final rawScreenName = newRoute.settings.name.toString().trim();
+      final screenName = rawScreenName.isEmpty
+          ? ReproStepsConstants.emptyScreenFallback
+          : rawScreenName;
       final maskedScreenName = ScreenNameMasker.I.mask(screenName);
 
       final route = InstabugRoute(

--- a/lib/src/utils/repro_steps_constants.dart
+++ b/lib/src/utils/repro_steps_constants.dart
@@ -1,0 +1,3 @@
+class ReproStepsConstants {
+  static const emptyScreenFallback = 'N/A';
+}

--- a/lib/src/utils/screen_loading/screen_loading_manager.dart
+++ b/lib/src/utils/screen_loading/screen_loading_manager.dart
@@ -110,16 +110,15 @@ class ScreenLoadingManager {
   @internal
   String sanitizeScreenName(String screenName) {
     const characterToBeRemoved = '/';
-    final lastIndex = screenName.length - 1;
     var sanitizedScreenName = screenName;
 
     if (screenName == characterToBeRemoved) {
       return 'ROOT_PAGE';
     }
-    if (screenName[0] == characterToBeRemoved) {
+    if (screenName.startsWith(characterToBeRemoved)) {
       sanitizedScreenName = sanitizedScreenName.substring(1);
     }
-    if (screenName[lastIndex] == characterToBeRemoved) {
+    if (screenName.endsWith(characterToBeRemoved)) {
       sanitizedScreenName =
           sanitizedScreenName.substring(0, sanitizedScreenName.length - 1);
     }

--- a/lib/src/utils/screen_name_masker.dart
+++ b/lib/src/utils/screen_name_masker.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:instabug_flutter/src/utils/repro_steps_constants.dart';
 
 typedef ScreenNameMaskingCallback = String Function(String screen);
 
@@ -13,8 +14,6 @@ class ScreenNameMasker {
 
   /// Shorthand for [instance]
   static ScreenNameMasker get I => instance;
-
-  static const emptyScreenNameFallback = "N/A";
 
   ScreenNameMaskingCallback? _screenNameMaskingCallback;
 
@@ -37,7 +36,7 @@ class ScreenNameMasker {
     final maskedScreen = _screenNameMaskingCallback!(screen).trim();
 
     if (maskedScreen.isEmpty) {
-      return emptyScreenNameFallback;
+      return ReproStepsConstants.emptyScreenFallback;
     }
 
     return maskedScreen;

--- a/test/utils/instabug_navigator_observer_test.dart
+++ b/test/utils/instabug_navigator_observer_test.dart
@@ -92,6 +92,25 @@ void main() {
     });
   });
 
+  test('should fallback to "N/A" when the screen name is empty', () {
+    fakeAsync((async) {
+      final route = createRoute('');
+      const fallback = 'N/A';
+
+      observer.didPush(route, previousRoute);
+
+      async.elapse(const Duration(milliseconds: 1000));
+
+      verify(
+        mScreenLoadingManager.startUiTrace(fallback, fallback),
+      ).called(1);
+
+      verify(
+        mHost.reportScreenChange(fallback),
+      ).called(1);
+    });
+  });
+
   test('should mask screen name when masking callback is set', () {
     const maskedScreen = 'maskedScreen';
 


### PR DESCRIPTION
## Description of the change

Fallback to "N/A" when a screen with an empty screen name is observed, this prevents crashes in `ScreenLoadingManager` because the screen name is empty and prevents the screen change event from being dropped.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: INSD-12170

Fixes #504 

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
