### PR TITLE
chore(android): bump sdk to v13.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- Bump Instabug Android SDK to v13.4.0 ([#506](https://github.com/Instabug/Instabug-Flutter/pull/506)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.4.0).
+- Bump Instabug Android SDK to v13.4.1 ([#509](https://github.com/Instabug/Instabug-Flutter/pull/509)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.4.0).
 - Bump Instabug iOS SDK to v13.4.0 ([#506](https://github.com/Instabug/Instabug-Flutter/pull/506)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/13.4.0).
 
 ### Fixed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'com.instabug.library:instabug:13.4.0'
+    api 'com.instabug.library:instabug:13.4.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-inline:3.12.1"


### PR DESCRIPTION
## Description of the change
chore(android): bump sdk to v13.4.1
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
JIRA ID : MOB-15858
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
