### PR TITLE
chore(ios): bump sdk to v13.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - Bump Instabug Android SDK to v13.4.1 ([#509](https://github.com/Instabug/Instabug-Flutter/pull/509)). [See release notes](https://github.com/Instabug/Instabug-Android/releases/tag/v13.4.0).
-- Bump Instabug iOS SDK to v13.4.0 ([#506](https://github.com/Instabug/Instabug-Flutter/pull/506)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/13.4.0).
+- Bump Instabug iOS SDK to v13.4.1 ([#510](https://github.com/Instabug/Instabug-Flutter/pull/510)). See release notes for [13.4.0](https://github.com/Instabug/Instabug-iOS/releases/tag/13.4.0) and [13.4.1](https://github.com/Instabug/Instabug-iOS/releases/tag/13.4.1).
 
 ### Fixed
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (13.4.0)
+  - Instabug (13.4.1)
   - instabug_flutter (13.4.0):
     - Flutter
-    - Instabug (= 13.4.0)
+    - Instabug (= 13.4.1)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  Instabug: 183aa1e038d01ddc000f06835f46a9ea1f6c992b
-  instabug_flutter: 2cae2dc6f1d9e2442154886b3740a47f3429d239
+  Instabug: 896a318fb64b282832e0eda6fce489dac74b5d48
+  instabug_flutter: b9f4503c3788c7346649bfe3396d6ca6e9711e96
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 8f7552fd115ace1988c3db54a69e4a123c448f84

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '13.4.0'
+  s.dependency 'Instabug', '13.4.1'
 end
 


### PR DESCRIPTION
## Description of the change

Bump Instabug iOS SDK to v13.4.1

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
Jira ID: MOB-15858

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
