### PR TITLE
chore:Set the minimum Flutter SDK version to v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v13.4.0...dev)
+
+### Changed
+
+- Set the minimum Flutter SDK version to v2.10.0. ([#518](https://github.com/Instabug/Instabug-Flutter/pull/518))
+
+
 ## [13.4.0](https://github.com/Instabug/Instabug-Flutter/compare/v13.3.0...v13.4.0) (September 29, 2024)
 
 ### Added

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,4 +36,4 @@ flutter:
 
 environment:
   sdk: ">=2.14.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=2.10.0"


### PR DESCRIPTION
## Description of the change
- Set the minimum Flutter SDK version to v2.10.0
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
JIRA ID : MOB-16290
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
