### PR TITLE
chore(ios): bump sdk to v14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for tracing network requests from Instabug to services like Datadog and New Relic ([#481](https://github.com/Instabug/Instabug-Flutter/pull/481)).
 
+### Changed
+
+- Bump Instabug iOS SDK to v14.0.0 ([#531](https://github.com/Instabug/Instabug-Flutter/pull/531)). See release notes for [14.0.0](https://github.com/Instabug/Instabug-iOS/releases/tag/14.0.0),
+
 ## [13.4.0](https://github.com/Instabug/Instabug-Flutter/compare/v13.3.0...v13.4.0) (September 29, 2024)
 
 ### Added

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (13.4.2)
+  - Instabug (14.0.0)
   - instabug_flutter (13.4.0):
     - Flutter
-    - Instabug (= 13.4.2)
+    - Instabug (= 14.0.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  Instabug: 7a71890217b97b1e32dbca96661845396b66da2f
-  instabug_flutter: a2df87e3d4d9e410785e0b1ffef4bc64d1f4b787
+  Instabug: a0beffc01658773e2fac549845782f8937707dc4
+  instabug_flutter: 71ec9d13d57a4958cabab59fe06792cade3bf754
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 8f7552fd115ace1988c3db54a69e4a123c448f84
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '13.4.2'
+  s.dependency 'Instabug', '14.0.0'
 end
 


### PR DESCRIPTION
## Description of the change
chore(ios): bump sdk to v14.0.0
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
JIRA ID : MOB-16651
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
