### PR TITLE
chore(iOS): bump sdk to v14.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v14.1.0...dev)
+## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v14.1.0...dev)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
-## [Unreleased](https://github.com/Instabug/Instabug-Flutter/compare/v14.1.0...dev)
+
+
+## [Unreleased](https://github.com/Instabug/Instabug-React-Native/compare/v14.1.0...dev)
+
+### Changed
+
+- Bump Instabug iOS SDK to v14.3.0 ([#1367](https://github.com/Instabug/Instabug-React-Native/pull/1367)). [See release notes](https://github.com/Instabug/Instabug-iOS/releases/tag/14.3.0).
 
 ### Fixed
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Instabug (14.1.0)
+  - Instabug (14.3.0)
   - instabug_flutter (14.0.0):
     - Flutter
-    - Instabug (= 14.1.0)
+    - Instabug (= 14.3.0)
   - OCMock (3.6)
 
 DEPENDENCIES:
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  Instabug: 8cbca8974168c815658133e2813f5ac3a36f8e20
-  instabug_flutter: a24751dfaedd29475da2af062d3e19d697438f72
+  Instabug: 97a4e694731f46bbc02dbe49ab29cc552c5e2f41
+  instabug_flutter: a8811895aec338ef338b5c00ce1ee1cfc4afd499
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
 
 PODFILE CHECKSUM: 8f7552fd115ace1988c3db54a69e4a123c448f84

--- a/ios/instabug_flutter.podspec
+++ b/ios/instabug_flutter.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig   = { 'OTHER_LDFLAGS' => '-framework "Flutter" -framework "Instabug"'}
 
   s.dependency 'Flutter'
-  s.dependency 'Instabug', '14.1.0'
+  s.dependency 'Instabug', '14.3.0'
 end
 


### PR DESCRIPTION
## Description of the change
> bump ios sdk to v14.3.0
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
