### PR TITLE
feat: add ndk crashes API

### DIFF
--- a/android/src/main/java/com/instabug/flutter/modules/CrashReportingApi.java
+++ b/android/src/main/java/com/instabug/flutter/modules/CrashReportingApi.java
@@ -70,4 +70,12 @@ public class CrashReportingApi implements CrashReportingPigeon.CrashReportingHos
         }
     }
 
+    @Override
+    public void setNDKEnabled(@NonNull Boolean isEnabled) {
+        if (isEnabled) {
+            CrashReporting.setNDKCrashesState(Feature.State.ENABLED);
+        } else {
+            CrashReporting.setNDKCrashesState(Feature.State.DISABLED);
+        }
+    }
 }

--- a/lib/src/modules/crash_reporting.dart
+++ b/lib/src/modules/crash_reporting.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:instabug_flutter/src/generated/crash_reporting.api.g.dart';
@@ -115,5 +116,15 @@ class CrashReporting {
       exception: frames,
     );
     return crashData;
+  }
+
+  /// Enables and disables NDK crash reporting.
+  /// [boolean] isEnabled
+  ///
+  /// Requires the [Instabug NDK package](https://pub.dev/packages/instabug_flutter_ndk) to be added to the project for this to work.
+  static Future<void> setNDKEnabled(bool isEnabled) async {
+    if (Platform.isAndroid) {
+      return _host.setNDKEnabled(isEnabled);
+    }
   }
 }

--- a/pigeons/crash_reporting.api.dart
+++ b/pigeons/crash_reporting.api.dart
@@ -12,4 +12,6 @@ abstract class CrashReportingHostApi {
     String? fingerprint,
     String nonFatalExceptionLevel,
   );
+
+  void setNDKEnabled(bool isEnabled);
 }


### PR DESCRIPTION
## Description of the change
> Added new API that sets the state of NDK crashes (enabled/disabled)
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> https://instabug.atlassian.net/browse/MOB-19406
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
