### PR TITLE
Fix exception in navigation observer with Flutter 3.35.3

### DIFF
--- a/packages/instabug_flutter/lib/src/utils/instabug_navigator_observer.dart
+++ b/packages/instabug_flutter/lib/src/utils/instabug_navigator_observer.dart
@@ -43,7 +43,7 @@ class InstabugNavigatorObserver extends NavigatorObserver {
         if (_steps.contains(route)) {
           await reportScreenChange(route.name);
         }
-        // Check again if this route is still in the array after async operation, remove it from the list
+        // Check again if this route is still in the list after async operation, remove it from the list
         if (_steps.contains(route)) {
           _steps.remove(route);
         }


### PR DESCRIPTION
## Description of the change
Hello,

It looks like when popping back to the root of our app the Instabug navigation observer causes an uncaught exception when removing an item from a list that is empty. There is an if check around it but it is an async/await. So it looks like in the meantime while the async call is running the list can change, causing this exception.

So I suspect it goes like this

`if _steps.isNotEmpty` -> `reportScreenChange` gets called and asynchronously `_steps` gets changed -> `_steps.removeLast()`; on a now empty list without checking if it is empty after the await

https://github.com/Instabug/Instabug-Flutter/issues/640

```
E/flutter ( 6807): [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: RangeError (length): Invalid value: Valid value range is empty: -1
E/flutter ( 6807): #0      List.[] (dart:core-patch/growable_array.dart)
E/flutter ( 6807): #1      List.removeLast (dart:core-patch/growable_array.dart:345:20)
E/flutter ( 6807): #2      InstabugNavigatorObserver.screenChanged.<anonymous closure> (package:instabug_flutter/src/utils/instabug_navigator_observer.dart:33:18)
E/flutter ( 6807): <asynchronous suspension>
```
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
